### PR TITLE
manifest: Set sdk-nrf version for v0.1.0 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: main
+      revision: 11c05001164e2e3f2a8b690c693f9aa976a2e5a5
       import: true


### PR DESCRIPTION
Setting sdk-nrf version for Serial Modem v0.1.0 release into `11c05001164e2e3f2a8b690c693f9aa976a2e5a5` used for last CI run.