### PR TITLE
app: Remove use of minimal libc

### DIFF
--- a/app/sysbuild/mcuboot/prj.conf
+++ b/app/sysbuild/mcuboot/prj.conf
@@ -28,8 +28,6 @@ CONFIG_MCUBOOT_LOG_LEVEL_INF=y
 ### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
 CONFIG_CBPRINTF_NANO=y
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=0
-### Use the minimal C library to reduce flash usage
-CONFIG_MINIMAL_LIBC=y
 
 ### Serial Modem
 # Do not use UART, for power saving


### PR DESCRIPTION
PR https://github.com/nrfconnect/sdk-nrf/pull/24387 cleaned the use of minimal lbc from sdk-nrf because it's not supposed to be used for real applications. Picolibc is supposed to be used.