### PR TITLE
sm_host: Fix DTR/RI pin selection

### DIFF
--- a/samples/sm_host_shell/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sm_host_shell/boards/nrf52840dk_nrf52840.overlay
@@ -39,8 +39,8 @@
 
 &gpio0 {
 	status = "okay";
-	/* Use PORT event for DTR (11) and RI (13) pins to ensure lower power consumption. */
-	sense-edge-mask = <0x00002800>;
+	/* Use PORT event for RI (13) pin to ensure lower power consumption. */
+	sense-edge-mask = <0x00002000>;
 };
 
 

--- a/samples/sm_host_shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/sm_host_shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -31,15 +31,15 @@
 / {
 	dte_dtr: dte_dtr {
 		compatible = "nordic,dte-dtr";
-		dtr-gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
-		ri-gpios = <&gpio0 25 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		dtr-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		ri-gpios = <&gpio0 28 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 	};
 };
 
 &gpio0 {
 	status = "okay";
-	/* Use PORT event for DTR (26) and RI (25) pins to ensure lower power consumption. */
-	sense-edge-mask = <0x06000000>;
+	/* Use PORT event for RI (28) pin to ensure lower power consumption. */
+	sense-edge-mask = <0x10000000>;
 };
 
 

--- a/samples/sm_host_shell/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/sm_host_shell/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -39,8 +39,8 @@
 
 &gpio0 {
 	status = "okay";
-	/* Use PORT event for DTR (30) and RI (31) pins to ensure lower power consumption. */
-	sense-edge-mask = <0xC0000000>;
+	/* Use PORT event for RI (31) pin to ensure lower power consumption. */
+	sense-edge-mask = <0x80000000>;
 };
 
 &pinctrl {


### PR DESCRIPTION
- Select previously used pins in nRF5340 DK.
- Port events only for inputs.