### PR TITLE
app: scripts: Stop trace collection before stopping CMUX

### DIFF
--- a/app/scripts/sm_stop_ppp.sh
+++ b/app/scripts/sm_stop_ppp.sh
@@ -14,17 +14,16 @@ if [ -f $PPP_PIDFILE ]; then
         kill -SIGTERM $(head -1 <$PPP_PIDFILE)
 fi
 
+# Stop trace collection
+if [ -f $TRACE_PID_FILE ]; then
+        echo "Stopping trace collection..."
+        kill $(cat $TRACE_PID_FILE) 2>/dev/null || true
+        rm -f $TRACE_PID_FILE
+fi
 
 # Wait for Shutdown script to complete
 if [ -f $PIDFILE ]; then
         echo "Waiting for Shutdown script to complete..."
         timeout 12s tail --pid=$(head -1 <$PIDFILE) -f /dev/null \
         || echo "Timeout waiting for Shutdown script to stop"
-fi
-
-# Stop trace collection
-if [ -f $TRACE_PID_FILE ]; then
-        echo "Stopping trace collection..."
-        kill $(cat $TRACE_PID_FILE) 2>/dev/null || true
-        rm -f $TRACE_PID_FILE
 fi


### PR DESCRIPTION
When traces are collected with CMUX trace backend, trace process needs to be stopped before stopping CMUX. If trace process is not stopped, I/O activity on CMUX'ed UART may cause ldattach process to enter uninterruptible sleep state instead of terminating correctly. When this happens, SUB serial device cannot be recovered without rebooting the Linux system.