### PR TITLE
app: Change sense-edge-mask to use BIT() macro

### DIFF
--- a/app/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/app/boards/nrf9151dk_nrf9151_ns.overlay
@@ -31,7 +31,7 @@
 &gpio0 {
 	status = "okay";
 	/* Use PORT event for DTR (8) pin to save power */
-	sense-edge-mask = <0x00000100>;
+	sense-edge-mask = <BIT(8)>;
 };
 
 

--- a/app/boards/thingy91x_nrf9151_ns.overlay
+++ b/app/boards/thingy91x_nrf9151_ns.overlay
@@ -25,5 +25,5 @@
 &gpio0 {
 	status = "okay";
 	/* Use PORT event for DTR (26) pin to save power */
-	sense-edge-mask = <0x04000000>;
+	sense-edge-mask = <BIT(26)>;
 };

--- a/app/overlay-external-mcu.overlay
+++ b/app/overlay-external-mcu.overlay
@@ -39,7 +39,7 @@
 &gpio0 {
 	status = "okay";
 	/* Use PORT event for DTR (31) pin to save power */
-	sense-edge-mask = <0x80000000>;
+	sense-edge-mask = <BIT(31)>;
 };
 
 &pinctrl {

--- a/app/overlay-nrf91m1.overlay
+++ b/app/overlay-nrf91m1.overlay
@@ -25,7 +25,7 @@
 &gpio0 {
 	status = "okay";
 	/* Use PORT event for DTR (31) pin to save power */
-	sense-edge-mask = <0x80000000>;
+	sense-edge-mask = <BIT(31)>;
 };
 
 /* Log / Trace UART */


### PR DESCRIPTION
Using sense-edge-mask = <BIT(31)>; is more readable than just the hex value.

Functionally it is the same.