### PR TITLE
app: HTTP client improvements

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -368,9 +368,12 @@ config SM_HTTPC_RESPONSE_TIMEOUT_MS
 	range 1000 300000
 	default 30000
 	help
-	  Idle timeout for an active HTTP request in milliseconds.
-	  The timeout is extended when data is received; if no activity occurs
-	  before it expires, the request is aborted and reported as an error.
+	  The timer is a sliding window: it resets each time data is sent or
+	  received (request headers, body upload chunks, response body chunks).
+	  If no activity occurs within this window the request is aborted and
+	  ``#XHTTPCSTAT: <fd>,-1,<bytes>`` is reported.
+	  A periodic background scan enforces the deadline even when the
+	  server stalls silently without closing the TCP connection.
 
 endif # SM_HTTPC
 

--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -63,8 +63,7 @@ struct http_request {
 	char *hostname;             /* Hostname (dynamically allocated) */
 	char *path;                 /* URL path (dynamically allocated) */
 	uint16_t port;              /* Port number */
-	char *request_body;         /* Dynamically allocated request body (POST/PUT) */
-	int request_body_len;       /* Bytes written into request_body */
+	int request_body_len;       /* Content-Length for request body (POST/PUT) */
 	char *extra_headers;        /* Extra HTTP headers (dynamically allocated) */
 	uint8_t *recv_buf;          /* Receive buffer (dynamically allocated) */
 	int recv_buf_len;           /* Bytes in receive buffer */
@@ -249,27 +248,27 @@ static int http_build_request(struct http_request *req, char *buf, size_t buf_le
 /* Compile-time length of a string literal (excludes null terminator) */
 #define STRLIT_LEN(s) (sizeof(s) - 1)
 
-/* Start HTTP request (non-blocking) */
-static int http_start_request(struct http_request *req)
+/* Calculate the buffer size needed to hold the HTTP request headers */
+static size_t http_send_buf_size(const struct http_request *req)
 {
-	int ret;
-	struct sm_socket *sock;
-	size_t send_buf_size;
-
-	LOG_INF("HTTP %d %s: %s:%d%s", req->method, http_method_str[req->method],
-		req->hostname, req->port, req->path);
-
-	/* Allocate send buffer sized to the actual header content */
-	send_buf_size =
-		strlen(http_method_str[req->method]) + 1 +
-		strlen(req->path) + STRLIT_LEN(HTTP_VERSION_LINE) +
-		STRLIT_LEN("Host: ") + strlen(req->hostname) + STRLIT_LEN("\r\n") +
-		STRLIT_LEN(HTTP_HDR_USER_AGENT) +
-		STRLIT_LEN(HTTP_HDR_ACCEPT) +
-		(req->request_body_len > 0 ?
+	return strlen(http_method_str[req->method]) + 1 +
+	       strlen(req->path) + STRLIT_LEN(HTTP_VERSION_LINE) +
+	       STRLIT_LEN("Host: ") + strlen(req->hostname) + STRLIT_LEN("\r\n") +
+	       STRLIT_LEN(HTTP_HDR_USER_AGENT) +
+	       STRLIT_LEN(HTTP_HDR_ACCEPT) +
+	       (req->request_body_len > 0 ?
 			STRLIT_LEN("Content-Length: 2147483647\r\n") : 0) +
-		(req->extra_headers ? strlen(req->extra_headers) : 0) +
-		STRLIT_LEN("\r\n") + 1; /* final blank line + null terminator */
+	       (req->extra_headers ? strlen(req->extra_headers) : 0) +
+	       STRLIT_LEN("\r\n") + 1; /* final blank line + null terminator */
+}
+
+/*
+ * Allocate req->send_buf and fill it with the HTTP request header block.
+ * Returns the number of bytes written, or a negative error code.
+ */
+static int http_alloc_build_headers(struct http_request *req)
+{
+	size_t send_buf_size = http_send_buf_size(req);
 
 	req->send_buf = malloc(send_buf_size);
 	if (!req->send_buf) {
@@ -277,8 +276,19 @@ static int http_start_request(struct http_request *req)
 		return -ENOMEM;
 	}
 
-	/* Build HTTP request into persistent buffer */
-	ret = http_build_request(req, req->send_buf, send_buf_size);
+	return http_build_request(req, req->send_buf, send_buf_size);
+}
+
+/* Start HTTP request (non-blocking) */
+static int http_start_request(struct http_request *req)
+{
+	int ret;
+	struct sm_socket *sock;
+
+	LOG_INF("HTTP %d %s: %s:%d%s", req->method, http_method_str[req->method],
+		req->hostname, req->port, req->path);
+
+	ret = http_alloc_build_headers(req);
 	if (ret < 0) {
 		return ret;
 	}
@@ -318,12 +328,6 @@ static void http_close_request(struct http_request *req)
 	if (req->extra_headers != NULL) {
 		free(req->extra_headers);
 		req->extra_headers = NULL;
-	}
-
-	if (req->request_body != NULL) {
-		free(req->request_body);
-		req->request_body = NULL;
-		req->request_body_len = 0;
 	}
 
 	if (req->recv_buf != NULL) {
@@ -576,8 +580,7 @@ static void http_process_request(struct http_request *req, uint8_t events)
 	}
 
 	/* POLLHUP during sending means the server closed the connection unexpectedly. */
-	if ((events & NRF_POLLHUP) &&
-	    (req->state == HTTP_STATE_SENDING_REQUEST || req->state == HTTP_STATE_SENDING_BODY)) {
+	if ((events & NRF_POLLHUP) && req->state == HTTP_STATE_SENDING_REQUEST) {
 		LOG_ERR("HTTP %d: Connection closed during send (events=0x%x)", req->fd,
 			events);
 		http_fail_request(req);
@@ -586,7 +589,6 @@ static void http_process_request(struct http_request *req, uint8_t events)
 
 	switch (req->state) {
 	case HTTP_STATE_SENDING_REQUEST:
-	case HTTP_STATE_SENDING_BODY:
 		/* Handle writable socket */
 		if (events & NRF_POLLOUT) {
 			ret = nrf_send(req->fd, req->send_ptr, req->send_remaining,
@@ -607,23 +609,10 @@ static void http_process_request(struct http_request *req, uint8_t events)
 			req->send_remaining -= ret;
 
 			if (req->send_remaining == 0) {
-				if (req->state == HTTP_STATE_SENDING_REQUEST &&
-				    req->request_body_len > 0) {
-					/* Move to sending body */
-					req->send_ptr = req->request_body;
-					req->send_remaining = req->request_body_len;
-					req->state = HTTP_STATE_SENDING_BODY;
-
-					/* Continue with POLLOUT to send body */
-					set_xapoll_events(sock, NRF_POLLOUT | NRF_POLLIN);
-				} else {
-					/* All sent, now wait for response */
-					req->state = HTTP_STATE_RECEIVING_HEADERS;
-					req->recv_buf_len = 0;
-
-					/* Set up for receiving */
-					set_xapoll_events(sock, NRF_POLLIN);
-				}
+				/* All headers sent, now wait for response */
+				req->state = HTTP_STATE_RECEIVING_HEADERS;
+				req->recv_buf_len = 0;
+				set_xapoll_events(sock, NRF_POLLIN);
 			} else {
 				/* More to send */
 				set_xapoll_events(sock, NRF_POLLOUT | NRF_POLLIN);
@@ -776,7 +765,41 @@ bool sm_at_httpc_poll_event(int fd, uint8_t events)
 	return (req && req->need_rearm_pollin);
 }
 
-/* Data mode callback for receiving POST/PUT body */
+/* Build HTTP request headers and send them synchronously for streaming POST/PUT */
+static int http_send_request_headers(struct http_request *req)
+{
+	int ret;
+	int sent;
+	int n;
+
+	LOG_INF("HTTP %d %s (streaming): %s:%d%s", req->method,
+		http_method_str[req->method], req->hostname, req->port, req->path);
+
+	ret = http_alloc_build_headers(req);
+	if (ret < 0) {
+		return ret;
+	}
+
+	req->state = HTTP_STATE_SENDING_BODY;
+	req->timeout_timestamp = k_uptime_get() + HTTP_RESPONSE_TIMEOUT_MS;
+
+	/* Send headers synchronously (blocking) */
+	sent = 0;
+	while (sent < ret) {
+		n = nrf_send(req->fd, req->send_buf + sent, ret - sent, 0);
+		if (n < 0) {
+			return -errno;
+		}
+		sent += n;
+	}
+
+	free(req->send_buf);
+	req->send_buf = NULL;
+
+	return 0;
+}
+
+/* Data mode callback: streams POST/PUT body directly to socket */
 static int http_datamode_callback(uint8_t op, const uint8_t *data, int len, uint8_t flags)
 {
 	int err = 0;
@@ -794,24 +817,56 @@ static int http_datamode_callback(uint8_t op, const uint8_t *data, int len, uint
 			return -EINVAL;
 		}
 
-		/* Store received body data */
-		memcpy(datamode_req->request_body + datamode_req->request_body_len, data, len);
-		datamode_req->request_body_len += len;
-		return len; /* Return number of bytes accepted */
+		/* Stream body chunk directly to the socket */
+		int sent = 0;
+
+		while (sent < len) {
+			int ret = nrf_send(datamode_req->fd, data + sent, len - sent, 0);
+
+			if (ret < 0) {
+				int err_code = -errno;
+				struct http_request *req_failed = datamode_req;
+
+				datamode_req = NULL;
+				LOG_ERR("Failed to stream request body: %d", err_code);
+				exit_datamode_handler(sm_at_host_get_current(), err_code);
+				http_fail_request(req_failed);
+				return err_code;
+			}
+			sent += ret;
+		}
+		return len;
 	} else if (op == DATAMODE_EXIT) {
 		if (datamode_req) {
-			/* Start the HTTP request now that we have the body */
-			err = http_start_request(datamode_req);
-			if (err) {
-				LOG_ERR("Failed to start request: %d", err);
-				/* Command already returned OK; send an error URC */
+			if (flags & SM_DATAMODE_FLAGS_EXIT_HANDLER) {
+				/* Data mode exited unexpectedly - body not fully sent */
+				LOG_WRN("HTTP %d: Data mode exited unexpectedly",
+					datamode_req->fd);
 				http_fail_request(datamode_req);
+			} else {
+				/* Body fully sent; arm XAPOLL to receive the response */
+				struct sm_socket *sock = find_socket(datamode_req->fd);
+
+				if (sock) {
+					datamode_req->state = HTTP_STATE_RECEIVING_HEADERS;
+					datamode_req->recv_buf_len = 0;
+					datamode_req->timeout_timestamp =
+						k_uptime_get() + HTTP_RESPONSE_TIMEOUT_MS;
+					err = set_xapoll_events(sock, NRF_POLLIN);
+					if (err) {
+						LOG_ERR("Failed to arm XAPOLL: %d", err);
+						http_fail_request(datamode_req);
+					}
+				} else {
+					LOG_ERR("HTTP %d: Socket not found after body send",
+						datamode_req->fd);
+					http_fail_request(datamode_req);
+				}
 			}
 			datamode_req = NULL;
 		}
 
-		if ((flags & SM_DATAMODE_FLAGS_EXIT_HANDLER) != 0) {
-			/* Datamode exited unexpectedly */
+		if (flags & SM_DATAMODE_FLAGS_EXIT_HANDLER) {
 			rsp_send(CONFIG_SM_DATAMODE_TERMINATOR);
 		}
 	}
@@ -1005,14 +1060,15 @@ STATIC int handle_at_httpcreq(enum at_parser_cmd_type cmd_type, struct at_parser
 			return err;
 		}
 
-		/* For POST/PUT with body, enter data mode */
+		/* For POST/PUT with body, send headers now then stream body via data mode */
 		if ((method == HTTP_POST || method == HTTP_PUT) && body_len > 0) {
-			LOG_INF("Entering data mode for %d bytes", body_len);
-			req->request_body = malloc(body_len);
-			if (!req->request_body) {
-				LOG_ERR("Failed to allocate request body (%d bytes)", body_len);
+			LOG_INF("Streaming %d bytes body", body_len);
+			req->request_body_len = body_len;
+			err = http_send_request_headers(req);
+			if (err) {
+				LOG_ERR("Failed to send request headers: %d", err);
 				http_close_request(req);
-				return -ENOMEM;
+				return err;
 			}
 			datamode_req = req;
 			/* Send #XHTTPCREQ before the OK so the host gets the socket fd

--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -7,6 +7,7 @@
 #define _POSIX_C_SOURCE 200809L /* for strdup() */
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/net/http/parser_url.h>
 #include <nrf_socket.h>
 #include <modem/at_parser.h>
@@ -26,6 +27,9 @@ LOG_MODULE_REGISTER(sm_httpc, CONFIG_SM_LOG_LEVEL);
 #define HTTP_EXTRA_HEADERS_SIZE   512
 #define HTTP_RESPONSE_TIMEOUT_MS  CONFIG_SM_HTTPC_RESPONSE_TIMEOUT_MS
 #define HTTP_MAX_REQUESTS         NRF_MODEM_MAX_SOCKET_COUNT
+
+/* Periodic scan, so idle timeout fires without a socket poll wakeup (silent server). */
+#define HTTP_TIMEOUT_SCAN_MS MIN(1000U, (uint32_t)HTTP_RESPONSE_TIMEOUT_MS / 4U)
 
 /* Fixed HTTP header lines */
 #define HTTP_VERSION_LINE    " HTTP/1.1\r\n"
@@ -75,10 +79,10 @@ struct http_request {
 	int total_received;         /* Total bytes received */
 	bool headers_complete;      /* Headers fully received */
 	bool need_rearm_pollin;     /* Flag for socket layer to re-arm POLLIN */
-	int64_t timeout_timestamp;  /* Idle timeout (resets on each data reception) */
+	int64_t timeout_timestamp;  /* Idle timeout deadline; reset on each send/receive */
 	struct modem_pipe *pipe;    /* AT pipe that created this request */
 	bool manual_mode;           /* Manual mode: body not auto-received, host pulls chunks */
-	int bytes_sent;             /* Total bytes sent for this request */
+	int bytes_sent;             /* Response-body bytes sent to the host */
 };
 
 static const char * const http_method_str[] = {
@@ -90,7 +94,6 @@ static const char * const http_method_str[] = {
 };
 
 static struct http_request *http_requests[HTTP_MAX_REQUESTS];
-static struct k_mutex http_mutex;
 static struct http_request *datamode_req; /* Request waiting for body data */
 
 /* Forward declarations */
@@ -103,6 +106,67 @@ static bool http_headers_complete(struct http_request *req, char *header_end,
 				  struct sm_socket *sock, bool hup);
 static int parse_http_status_code(const char *buf, int *status_code);
 static int parse_content_length(const char *buf, const char *header_end, int *length);
+static void http_timeout_work_fn(struct k_work *work);
+
+static K_MUTEX_DEFINE(http_mutex);
+static K_WORK_DELAYABLE_DEFINE(http_timeout_dwork,  http_timeout_work_fn);
+
+static bool http_any_active_request_unlocked(void)
+{
+	for (int i = 0; i < HTTP_MAX_REQUESTS; i++) {
+		if (http_requests[i] != NULL && http_requests[i]->state != HTTP_STATE_IDLE) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* Arm the scan timer when a request enters a non-idle state (safe without http_mutex). */
+static void http_timeout_monitor_arm(void)
+{
+	(void)k_work_reschedule_for_queue(&sm_work_q, &http_timeout_dwork,
+					  K_MSEC(HTTP_TIMEOUT_SCAN_MS));
+}
+
+/*
+ * Sole enforcement of HTTP idle timeout (SM_HTTPC_RESPONSE_TIMEOUT_MS sliding window).
+ * Runs on sm_work_q; reschedules while any request remains active.
+ */
+static void http_timeout_work_fn(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	k_mutex_lock(&http_mutex, K_FOREVER);
+
+	for (int i = 0; i < HTTP_MAX_REQUESTS; i++) {
+		struct http_request *req = http_requests[i];
+
+		if (req == NULL || req->state == HTTP_STATE_IDLE) {
+			continue;
+		}
+
+		/* Body is being streamed via data mode; data mode manages its own
+		 * lifecycle. Do not apply the response idle timeout here.
+		 */
+		if (req->state == HTTP_STATE_SENDING_BODY) {
+			continue;
+		}
+
+		if (k_uptime_get() > req->timeout_timestamp) {
+			LOG_ERR("HTTP request %d idle timeout state %d", req->fd, req->state);
+			http_fail_request(req);
+		}
+	}
+
+	const bool any = http_any_active_request_unlocked();
+
+	k_mutex_unlock(&http_mutex);
+
+	if (any) {
+		http_timeout_monitor_arm();
+	}
+}
 
 /* Find request by socket fd */
 static struct http_request *find_request(int fd)
@@ -249,7 +313,7 @@ static int http_build_request(struct http_request *req, char *buf, size_t buf_le
 #define STRLIT_LEN(s) (sizeof(s) - 1)
 
 /* Calculate the buffer size needed to hold the HTTP request headers */
-static size_t http_send_buf_size(const struct http_request *req)
+static size_t http_headers_size(const struct http_request *req)
 {
 	return strlen(http_method_str[req->method]) + 1 +
 	       strlen(req->path) + STRLIT_LEN(HTTP_VERSION_LINE) +
@@ -268,7 +332,7 @@ static size_t http_send_buf_size(const struct http_request *req)
  */
 static int http_alloc_build_headers(struct http_request *req)
 {
-	size_t send_buf_size = http_send_buf_size(req);
+	size_t send_buf_size = http_headers_size(req);
 
 	req->send_buf = malloc(send_buf_size);
 	if (!req->send_buf) {
@@ -308,6 +372,8 @@ static int http_start_request(struct http_request *req)
 		LOG_ERR("Failed to set XAPOLL events: %d", ret);
 		return ret;
 	}
+
+	http_timeout_monitor_arm();
 
 	return 0;
 }
@@ -350,6 +416,11 @@ static void http_close_request(struct http_request *req)
 
 		req->fd = -1;
 	}
+	/* Clear datamode_req if it points to this request */
+	if (datamode_req == req) {
+		datamode_req = NULL;
+	}
+
 	/* Free this request and clear its slot */
 	for (int i = 0; i < HTTP_MAX_REQUESTS; i++) {
 		if (http_requests[i] == req) {
@@ -565,13 +636,6 @@ static void http_process_request(struct http_request *req, uint8_t events)
 	LOG_DBG("HTTP %d: process_request state=%d events=0x%x time=%lld timeout=%lld", req->fd,
 		req->state, events, k_uptime_get(), req->timeout_timestamp);
 
-	/* Check for idle timeout (no activity for HTTP_RESPONSE_TIMEOUT_MS) */
-	if (k_uptime_get() > req->timeout_timestamp) {
-		LOG_ERR("HTTP request %d timed out in state %d", req->fd, req->state);
-		http_fail_request(req);
-		return;
-	}
-
 	/* POLLERR/POLLNVAL are always fatal; POLLHUP is handled per-state below. */
 	if (events & (NRF_POLLERR | NRF_POLLNVAL)) {
 		LOG_ERR("HTTP %d: Socket error (events=0x%x)", req->fd, events);
@@ -676,7 +740,7 @@ static void http_process_request(struct http_request *req, uint8_t events)
 				return;
 			}
 
-			/* Data received - update idle timeout (resets on each recv) */
+			/* Data received - update idle timeout */
 			req->recv_buf_len += ret;
 			req->recv_buf[req->recv_buf_len] = '\0';
 			req->total_received += ret;
@@ -780,7 +844,6 @@ static int http_send_request_headers(struct http_request *req)
 		return ret;
 	}
 
-	req->state = HTTP_STATE_SENDING_BODY;
 	req->timeout_timestamp = k_uptime_get() + HTTP_RESPONSE_TIMEOUT_MS;
 
 	/* Send headers synchronously (blocking) */
@@ -791,10 +854,16 @@ static int http_send_request_headers(struct http_request *req)
 			return -errno;
 		}
 		sent += n;
+		req->timeout_timestamp = k_uptime_get() + HTTP_RESPONSE_TIMEOUT_MS;
 	}
 
 	free(req->send_buf);
 	req->send_buf = NULL;
+
+	/* Headers sent; body will now be streamed via data mode. */
+	req->state = HTTP_STATE_SENDING_BODY;
+
+	http_timeout_monitor_arm();
 
 	return 0;
 }
@@ -835,11 +904,23 @@ static int http_datamode_callback(uint8_t op, const uint8_t *data, int len, uint
 			}
 			sent += ret;
 		}
+
+		/* Slide response idle window: slow UART upload is activity, not server wait. */
+		if (len > 0) {
+			k_mutex_lock(&http_mutex, K_FOREVER);
+			if (datamode_req != NULL) {
+				datamode_req->timeout_timestamp =
+					k_uptime_get() + HTTP_RESPONSE_TIMEOUT_MS;
+			}
+			k_mutex_unlock(&http_mutex);
+		}
+
 		return len;
 	} else if (op == DATAMODE_EXIT) {
 		if (datamode_req) {
 			if (flags & SM_DATAMODE_FLAGS_EXIT_HANDLER) {
 				/* Data mode exited unexpectedly - body not fully sent */
+				rsp_send(CONFIG_SM_DATAMODE_TERMINATOR);
 				LOG_WRN("HTTP %d: Data mode exited unexpectedly",
 					datamode_req->fd);
 				http_fail_request(datamode_req);
@@ -1290,12 +1371,3 @@ STATIC int handle_at_httpccancel(enum at_parser_cmd_type cmd_type, struct at_par
 
 	return err;
 }
-
-int sm_at_httpc_init(void)
-{
-	k_mutex_init(&http_mutex);
-
-	return 0;
-}
-
-SYS_INIT(sm_at_httpc_init, APPLICATION, 10);

--- a/doc/app/at_httpc.rst
+++ b/doc/app/at_httpc.rst
@@ -68,7 +68,10 @@ Syntax
   * ``0`` - No request body.
   * Positive integer - Length of the request body in bytes.
     Valid for POST and PUT only.
-    When set, the command responds with ``OK`` and enters data mode.
+    When set, the HTTP request headers are sent to the server immediately when the AT command
+    is processed.
+    The command then responds with ``OK`` and enters data mode.
+    Body bytes are forwarded to the server as they are received from the host in data mode.
     The host must send exactly this many bytes as the request body.
     Data mode exits and ``#XDATAMODE: 0`` is reported when all bytes have been processed.
 

--- a/doc/app/at_httpc.rst
+++ b/doc/app/at_httpc.rst
@@ -68,8 +68,7 @@ Syntax
   * ``0`` - No request body.
   * Positive integer - Length of the request body in bytes.
     Valid for POST and PUT only.
-    When set, the HTTP request headers are sent to the server immediately when the AT command
-    is processed.
+    When set, the HTTP request headers are sent to the server immediately when the AT command is processed.
     The command then responds with ``OK`` and enters data mode.
     Body bytes are forwarded to the server as they are received from the host in data mode.
     The host must send exactly this many bytes as the request body.
@@ -366,6 +365,19 @@ Example
    AT#XHTTPCDATA=?
    #XHTTPCDATA: <socket_fd>[,<length>]
    OK
+
+Idle timeout
+============
+
+Every active HTTP request has a sliding idle timeout controlled by the :ref:`CONFIG_SM_HTTPC_RESPONSE_TIMEOUT_MS <CONFIG_SM_HTTPC_RESPONSE_TIMEOUT_MS>` Kconfig option (default 30 seconds).
+The timer resets each time data is sent or received:
+
+* Sending request headers or body upload chunks (POST/PUT data mode).
+* Receiving response headers or body bytes.
+* Pulling a body chunk in manual mode (``AT#XHTTPCDATA``).
+
+If no such activity occurs within the configured window, the request is aborted and ``#XHTTPCSTAT: <socket_fd>,-1,<total_bytes>`` is emitted.
+The timeout is enforced by a background timer that fires independently of normal socket poll events, so a server that stalls silently (no TCP RST or FIN) is also detected.
 
 HTTP request cancel #XHTTPCCANCEL
 =================================

--- a/doc/app/sm_configuration.rst
+++ b/doc/app/sm_configuration.rst
@@ -192,6 +192,22 @@ CONFIG_SM_MQTTC_MESSAGE_BUFFER_LEN - Size of the buffer for the MQTT library
    This option specifies the maximum message size which can be transmitted or received through MQTT (excluding PUBLISH payload).
    The default value is 512, meaning 512 bytes for TX and RX, respectively.
 
+.. _CONFIG_SM_HTTPC:
+
+CONFIG_SM_HTTPC - HTTP client support in |SM|
+   This option enables the HTTP client AT commands for making HTTP/HTTPS requests.
+   See :ref:`SM_AT_HTTPC` for more information.
+
+   When enabled, the following sub-option is available:
+
+   .. _CONFIG_SM_HTTPC_RESPONSE_TIMEOUT_MS:
+
+   CONFIG_SM_HTTPC_RESPONSE_TIMEOUT_MS - HTTP client idle timeout (ms)
+      Idle timeout for an active HTTP request in milliseconds.
+      The timer is a sliding window that resets each time data is sent or received (request headers, body upload chunks, and response body chunks).
+      If no activity occurs within this window the request is aborted, and ``#XHTTPCSTAT: <fd>,-1,<bytes>`` is reported.
+      The default value is 30000 (30 seconds).
+
 .. _CONFIG_SM_UART_RX_BUF_COUNT:
 
 CONFIG_SM_UART_RX_BUF_COUNT - Receive buffers for UART.


### PR DESCRIPTION
Remove intermediate buffer allocation for HTTP body data. Instead, pipe incoming data directly from data mode to the socket, reducing memory overhead and enabling transfer of large payloads.

Add periodic HTTP request timeout watchdog using k_work_delayable. Previously, request timeouts were only evaluated when XAPOLL events were received, allowing stalled requests to go undetected during periods of inactivity.