### PR TITLE
[Backport main] app: Discard received RX before work queue is active

### DIFF
--- a/app/src/sm_uart_handler.c
+++ b/app/src/sm_uart_handler.c
@@ -298,6 +298,12 @@ static void uart_callback(const struct device *dev, struct uart_event *evt, void
 		uart_callback_notify_pipe_transmit_idle();
 		break;
 	case UART_RX_RDY:
+		if (!(sm_work_q.flags & K_WORK_QUEUE_STARTED)) {
+			/* Discard data at callback level while the work queue is not
+			 * running yet. Freeing here keeps slab blocks available.
+			 */
+			break;
+		}
 		rx_buf_ref(evt->data.rx.buf);
 		rx_event.buf = &evt->data.rx.buf[evt->data.rx.offset];
 		rx_event.len = evt->data.rx.len;


### PR DESCRIPTION
Backport 6186a7237a44db120050f778e8c4a5afd234ff83 from #249.