### PR TITLE
doc: Add bootup sequence

### DIFF
--- a/doc/images/boot-up-sequence.svg
+++ b/doc/images/boot-up-sequence.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="900"
+   height="560"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg">
+  <defs id="defs1">
+    <marker
+       style="overflow:visible"
+       id="Arrow2"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       markerWidth="7.6999998"
+       markerHeight="5.5999999"
+       viewBox="0 0 7.7 5.6"
+       preserveAspectRatio="xMidYMid">
+      <path
+         transform="scale(0.7)"
+         d="M -2,-4 9,0 -2,4 c 2,-2.33 2,-5.66 0,-8 z"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:none"/>
+    </marker>
+    <style id="style1">
+      .signal-line { stroke: #333; stroke-width: 2; fill: none; }
+      .signal-label { font-family: Arial, sans-serif; font-size: 11px; fill: #333; }
+      .signal-name { font-family: Arial, sans-serif; font-size: 13px; font-weight: bold; fill: #2c5aa0; }
+      .timing-label { font-family: Arial, sans-serif; font-size: 10px; fill: #666; }
+      .grid-line { stroke: #ddd; stroke-width: 1; stroke-dasharray: 2,2; }
+      .inactive { stroke: #999; stroke-width: 1.5; }
+      .active { stroke: #2c5aa0; stroke-width: 2; }
+      .high { stroke: #2c5aa0; stroke-width: 2; }
+      .low { stroke: #d32f2f; stroke-width: 2; }
+      .ready-label { font-family: Arial, sans-serif; font-size: 11px; font-weight: bold; fill: #2e7d32; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect x="0" y="0" width="900" height="560" fill="#fafafa" stroke="#ccc" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="450" y="25" text-anchor="middle" class="signal-name" font-size="16">Boot-up Sequence</text>
+
+  <!-- Signal level legend -->
+ <text x="120" y="45" class="signal-label" fill="#2c5aa0">High</text>
+  <text x="120" y="60" class="signal-label" fill="#d32f2f">Low</text>
+
+  <!-- Signal names on the left -->
+  <text x="30" y="80" class="signal-name">ENABLE</text>
+  <text x="30" y="162" class="signal-name">DTR</text>
+  <text x="30" y="242" class="signal-name">CTS</text>
+  <text x="30" y="322" class="signal-name">RTS</text>
+  <text x="30" y="402" class="signal-name">TX</text>
+  <text x="30" y="482" class="signal-name">RX</text>
+
+  <!-- Time axis -->
+  <line x1="150" y1="520" x2="850" y2="520" class="signal-line" stroke-width="2"/>
+  <text x="500" y="553" text-anchor="middle" class="signal-label" font-size="12">Time</text>
+
+  <!-- Grid lines at t0=240, t1=385, t2=570 -->
+  <line x1="240" y1="48" x2="240" y2="520" class="grid-line"/>
+  <line x1="385" y1="48" x2="385" y2="520" class="grid-line"/>
+  <line x1="570" y1="48" x2="570" y2="520" class="grid-line"/>
+
+  <!-- Timing markers -->
+  <text x="240" y="535" text-anchor="middle" class="timing-label">t0</text>
+  <text x="385" y="535" text-anchor="middle" class="timing-label">t1</text>
+  <text x="570" y="535" text-anchor="middle" class="timing-label">t2</text>
+
+  <!-- ===== ENABLE signal (active high) ===== -->
+  <!-- Inactive (low/red) from x=150 to t0=240 -->
+  <line x1="150" y1="91" x2="240" y2="91" class="low"/>
+  <!-- Rising edge at t0 -->
+  <line x1="240" y1="91" x2="240" y2="65" class="signal-line" stroke-width="2"/>
+  <!-- Active (high/blue) from t0 to end -->
+  <line x1="240" y1="65" x2="850" y2="65" class="high"/>
+  <!-- Signal labels -->
+  <text x="194" y="86" text-anchor="middle" class="signal-label">Inactive</text>
+  <text x="590" y="60" text-anchor="middle" class="signal-label">Active</text>
+
+  <!-- ===== DTR signal (active low) ===== -->
+  <!-- Inactive (high/blue) from x=150 to t0=240 -->
+  <line x1="150" y1="147" x2="240" y2="147" class="inactive"/>
+  <!-- Falling edge at t0 -->
+  <line x1="240" y1="147" x2="240" y2="173" class="signal-line" stroke-width="2"/>
+  <!-- Asserted (low/red) from t0 to end -->
+  <line x1="240" y1="173" x2="850" y2="173" class="low"/>
+  <!-- Signal labels -->
+  <text x="194" y="142" text-anchor="middle" class="signal-label">Inactive (Floating)</text>
+  <text x="590" y="168" text-anchor="middle" class="signal-label">Asserted (Low)</text>
+
+  <!-- ===== CTS signal (active low; host drives low when enabling UART) ===== -->
+  <!-- Inactive (high/blue) from x=150 to t0=240 -->
+  <line x1="150" y1="227" x2="240" y2="227" class="inactive"/>
+  <!-- Falling edge at t0 -->
+  <line x1="240" y1="227" x2="240" y2="253" class="signal-line" stroke-width="2"/>
+  <!-- Asserted (low/red) from t0 to end -->
+  <line x1="240" y1="253" x2="850" y2="253" class="low"/>
+  <!-- Signal labels -->
+  <text x="194" y="222" text-anchor="middle" class="signal-label">Inactive (Floating)</text>
+  <text x="590" y="248" text-anchor="middle" class="signal-label">Asserted (Low)</text>
+
+  <!-- ===== RTS signal (nRF91 RTS output, active low) ===== -->
+  <!-- Inactive (high/blue) from x=150 to t1=385 -->
+  <line x1="150" y1="307" x2="385" y2="307" class="high"/>
+  <!-- Falling edge at t1 -->
+  <line x1="385" y1="307" x2="385" y2="333" class="signal-line" stroke-width="2"/>
+  <!-- Asserted (low/red) from t1 to end -->
+  <line x1="385" y1="333" x2="850" y2="333" class="low"/>
+  <!-- Signal labels -->
+  <text x="267" y="302" text-anchor="middle" class="signal-label">Inactive (Host pull-up)</text>
+  <text x="690" y="328" text-anchor="middle" class="signal-label">Asserted (Low)</text>
+
+  <!-- ===== TX signal (nRF91 TX output) ===== -->
+  <!-- Opening (diverge) at t1: start of "Ready" data burst -->
+  <line x1="385" y1="387" x2="385" y2="413" class="signal-line" stroke-width="1.5"/>
+  <!-- Data burst fill (t1 to t2) -->
+  <rect x="386" y="388" width="183" height="25" fill="#c8ddf0" stroke="none"/>
+  <!-- Top border of burst — continues as idle line after t2 -->
+  <line x1="150" y1="387" x2="850" y2="387" class="active"/>
+  <!-- Bottom border of burst (t1 to t2 only) -->
+  <line x1="385" y1="413" x2="570" y2="413" class="active"/>
+  <!-- Closing (converge) at t2: bottom border back to idle high -->
+  <line x1="570" y1="413" x2="570" y2="387" class="signal-line" stroke-width="1.5"/>
+  <!-- "Ready" label inside the burst -->
+  <text x="477" y="404" text-anchor="middle" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#163d6e">Ready</text>
+  <!-- Signal labels -->
+  <text x="267" y="380" text-anchor="middle" class="signal-label">Inactive (Host pull-up)</text>
+  <text x="720" y="382" text-anchor="middle" class="signal-label">Idle</text>
+
+  <!-- ===== RX signal (nRF91 RX input, data line) ===== -->
+  <!-- Inactive (gray) from x=150 to t1=385 -->
+  <line x1="150" y1="493" x2="385" y2="493" class="inactive"/>
+  <!-- Rising edge at t1 -->
+  <line x1="385" y1="493" x2="385" y2="467" class="signal-line" stroke-width="2"/>
+  <!-- Active (blue) from t1 to end -->
+  <line x1="385" y1="467" x2="850" y2="467" class="active"/>
+  <!-- Signal labels -->
+  <text x="267" y="488" text-anchor="middle" class="signal-label">Inactive (Floating)</text>
+  <text x="720" y="462" text-anchor="middle" class="signal-label">Active</text>
+
+  <!-- ===== Phase annotations ===== -->
+
+  <!-- t0: ENABLE + DTR + CTS all assert simultaneously -->
+  <text x="240" y="107" text-anchor="middle" class="timing-label">Host asserts ENABLE</text>
+  <text x="240" y="193" text-anchor="middle" class="timing-label">Host asserts DTR</text>
+  <text x="240" y="269" text-anchor="middle" class="timing-label">Host enables UART</text>
+
+  <!-- ~2000 ms boot annotation between t0 and t2 -->
+  <line x1="245" y1="510" x2="565" y2="510"
+        stroke="#666" stroke-width="1"
+        marker-start="url(#Arrow2)" marker-end="url(#Arrow2)"/>
+  <text x="405" y="505" text-anchor="middle" class="timing-label">~2000 ms</text>
+
+  <!-- t1: Serial Modem Ready -->
+  <text x="340" y="349" text-anchor="start" class="timing-label">Serial Modem Ready</text>
+
+  <!-- t2: Host received Ready message -->
+  <text x="540" y="430" text-anchor="start" class="timing-label">Host received</text>
+  <text x="540" y="442" text-anchor="start" class="timing-label">Ready message</text>
+
+</svg>

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -18,6 +18,7 @@
 .. _`nrf9151dk`: https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/boards/nordic/nrf9151dk/doc/index.html#nrf9151dk
 .. _`nRF9151 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/nRF9151_html5_keyfeatures.html
 .. _`nRF9151 LGA pin assignments`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/pin.html#ariaid-title2
+.. _`nRF9151 Hardware Design Guidelines — ENABLE`: https://docs.nordicsemi.com/bundle/nwp_056/page/WP/nwp_054/enable.html
 .. _`Thingy91x_firmware_update`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/thingy91x/thingy91x_updating_fw_programmer.html#updating_the_firmware_on_the_nrf5340_soc
 .. _`shared TF-M logging`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf91/nrf91_snippet.html#tfm-enable-share-uart
 

--- a/doc/uart_configuration.rst
+++ b/doc/uart_configuration.rst
@@ -362,6 +362,27 @@ The modem detects the DTR assertion and powers up its UART interface, allowing c
 
    Sequence diagram showing host-initiated wake-up of the modem
 
+
+Boot-up scenario
+================
+
+To boot-up the |SM| application, the host asserts **ENABLE**, **DTR**, and enables its UART (driving |SM| **CTS** low).
+The |SM| firmware initializes within approximately 500 ms, after which it activates its UART and asserts **RTS** to signal readiness.
+|SM| then transmits a ``"Ready"`` message on **TX**, confirming that the link is operational.
+
+.. figure:: images/boot-up-sequence.svg
+   :alt: Boot-up sequence diagram
+
+   Signal sequence during boot-up
+
+
+The **ENABLE** pin (pin **10** on the nRF9151 SiP) is a high-impedance control input for the nRF9151 internal power management unit (PMU).
+Driving it to a logic high powers on the SiP.
+After **ENABLE** goes high, the |SM| application firmware typically starts within approximately 500 ms.
+Driving it to a logic low brings the device into an extremely low-current state.
+Any internal state not retained in non‑volatile memory is lost, and a full boot-up sequence is required when **ENABLE** is reasserted.
+See `nRF9151 Hardware Design Guidelines — ENABLE`_ for more information about the ENABLE pin.
+
 .. _uart_without_flow_control:
 
 Operating without hardware flow control
@@ -380,6 +401,7 @@ The host can operate without connecting the hardware flow control signals (CTS/R
 * The host must enable its own UART before asserting DTR.
 * To detect when |SM| is ready to receive, monitor the RI signal (de-asserted when ready) or use a sufficient timeout after DTR assertion.
 * See `Incoming data wake-up`_ for detailed timing information.
+* In boot-up scenarios, the host must wait for the ``"Ready"`` message from |SM| before sending any data.
 
 **Buffer configuration:**
 


### PR DESCRIPTION
Add bootup sequence for illustrating how the nRF9151 SiP is enabled and how the host device should initialize the UART communication.