### PR TITLE
app: scripts: Update cbor2 version to 5.9.0

### DIFF
--- a/app/scripts/requirements.txt
+++ b/app/scripts/requirements.txt
@@ -1,3 +1,3 @@
 # This file lists all the dependencies required to run the sm_dfu_host.py script.
 pyserial
-cbor2==5.7.1
+cbor2==5.9.0


### PR DESCRIPTION
cbor2 had a bug due to which we couldn't use it. Older versions worked. Now that 5.9.0 is released, let's use it.