### PR TITLE
app: AT+CGDATA should connect the PDP context 

### DIFF
--- a/app/src/sm_at_host.c
+++ b/app/src/sm_at_host.c
@@ -440,6 +440,12 @@ static void at_pipe_rx_work_fn(struct k_work *work)
 		LOG_WRN("AT pipe RX work: no pipe assigned (ctx: %p)", (void *)ctx);
 		return;
 	}
+
+	/* Do not parse more commands, if we are still executing */
+	if (ctx->executing) {
+		return;
+	}
+
 	/* Set as current context */
 	sm_at_host_set_current_ctx(ctx);
 
@@ -1160,14 +1166,17 @@ static void cmd_send(struct sm_at_host_ctx *ctx, uint8_t *buf, size_t cmd_length
 		return;
 	}
 
-	/* Block URCs while command is executing, even if idle timer triggers */
+	/* Block CMDs & URCs while command is executing, even if idle timer triggers */
 	ctx->executing = true;
 	/* Send to modem.
 	 * Reserve space for CRLF in the response buffer.
 	 */
 	err = nrf_modem_at_cmd(sm_response_buf + strlen(CRLF_STR),
 			       sizeof(sm_response_buf) - strlen(CRLF_STR), "%s", at_cmd);
-	if (err == -SILENT_AT_COMMAND_RET) {
+
+	if (err == -AT_COMMAND_CONTINUE_RET) {
+		return;
+	} else if (err == -SILENT_AT_COMMAND_RET) {
 		ctx->executing = false;
 		return;
 	} else if (err < 0) {
@@ -1195,6 +1204,19 @@ static void cmd_send(struct sm_at_host_ctx *ctx, uint8_t *buf, size_t cmd_length
 		}
 	}
 	ctx->executing = false;
+}
+
+void sm_at_host_cmd_done(struct sm_at_host_ctx *ctx)
+{
+	if (!sm_at_ctx_check(ctx)) {
+		return;
+	}
+	ctx->executing = false;
+
+	/* Continue processing received data, if there is any */
+	if (is_open(ctx)) {
+		k_work_submit_to_queue(&sm_work_q, &ctx->rx_work);
+	}
 }
 
 static size_t cmd_rx_handler(struct sm_at_host_ctx *ctx, uint8_t c)
@@ -1464,6 +1486,16 @@ void urc_send_to(struct modem_pipe *pipe, const char *fmt, ...)
 void rsp_send(const char *fmt, ...)
 {
 	struct sm_at_host_ctx *ctx = sm_at_host_get_current();
+	va_list arg_ptr;
+
+	va_start(arg_ptr, fmt);
+	rsp_send_internal(ctx, false, fmt, arg_ptr);
+	va_end(arg_ptr);
+}
+
+void rsp_send_to(struct modem_pipe *pipe, const char *fmt, ...)
+{
+	struct sm_at_host_ctx *ctx = sm_at_host_get_ctx_from(pipe);
 	va_list arg_ptr;
 
 	va_start(arg_ptr, fmt);
@@ -1834,6 +1866,7 @@ static struct sm_at_host_ctx *sm_at_host_create(struct modem_pipe *pipe)
 	ctx = sm_at_host_get_urc_ctx();
 	if (ctx && atomic_ptr_cas(&ctx->pipe, NULL, pipe)) {
 		LOG_DBG("Reusing first AT host instance %p for pipe %p", (void *)ctx, (void *)pipe);
+		ctx->executing = false;
 		modem_pipe_attach(pipe, at_pipe_event_handler, ctx);
 		if (urcs_queued) {
 			sm_at_host_event_notify(ctx, SM_EVENT_URC);

--- a/app/src/sm_at_host.h
+++ b/app/src/sm_at_host.h
@@ -84,6 +84,15 @@ void sm_at_host_uninit(void);
 void rsp_send(const char *fmt, ...);
 
 /**
+ * @brief Send AT command response to a specific modem pipe
+ *
+ * @param pipe Modem pipe to send the response through
+ * @param fmt Response message format string
+ *
+ */
+void rsp_send_to(struct modem_pipe *pipe, const char *fmt, ...);
+
+/**
  * @brief Send URC to a specific modem pipe.
  *
  * This is safe to call with NULL pointer for pipe, in which case message is dropped.
@@ -149,6 +158,8 @@ bool in_at_mode_ctx(struct sm_at_host_ctx *ctx);
 bool in_at_mode_pipe(struct modem_pipe *pipe);
 bool is_idle_ctx(struct sm_at_host_ctx *ctx);
 bool is_idle_pipe(struct modem_pipe *pipe);
+bool is_open_pipe(struct modem_pipe *pipe);
+bool is_open_ctx(struct sm_at_host_ctx *ctx);
 
 /**
  * @brief Check whether AT host context is in data mode
@@ -312,6 +323,24 @@ static inline struct modem_pipe *sm_at_host_get_urc_pipe(void)
 {
 	return sm_at_host_get_pipe(sm_at_host_get_urc_ctx());
 }
+
+/**
+ * @brief Mark the background execution of AT command as completed.
+ *
+ * @param ctx AT host context
+ */
+void sm_at_host_cmd_done(struct sm_at_host_ctx *ctx);
+
+static inline void sm_at_host_cmd_done_pipe(struct modem_pipe *pipe)
+{
+	return sm_at_host_cmd_done(sm_at_host_get_ctx_from(pipe));
+}
+
+#define cmd_done(X) \
+		_Generic((X), \
+			struct sm_at_host_ctx * : sm_at_host_cmd_done, \
+			struct modem_pipe * : sm_at_host_cmd_done_pipe \
+			)(X)
 
 /**
  * @brief Submit a work to be executed when the current AT command processing is done.

--- a/app/src/sm_defines.h
+++ b/app/src/sm_defines.h
@@ -13,9 +13,10 @@
 #define INVALID_SOCKET       -1
 
 enum {
-	/* The command ran successfully and doesn't want the automatic response to be sent. */
+	/** The command ran successfully and doesn't want the automatic response to be sent. */
 	SILENT_AT_COMMAND_RET = __ELASTERROR,
-	AT_COMMAND_CONTINUE_RET, /**< The AT command continues to execute on background */
+	/** The AT command continues to execute on background */
+	AT_COMMAND_CONTINUE_RET,
 };
 
 /** The maximum allowed length of an AT command/response passed through the Serial Modem */

--- a/app/src/sm_defines.h
+++ b/app/src/sm_defines.h
@@ -15,6 +15,7 @@
 enum {
 	/* The command ran successfully and doesn't want the automatic response to be sent. */
 	SILENT_AT_COMMAND_RET = __ELASTERROR,
+	AT_COMMAND_CONTINUE_RET, /**< The AT command continues to execute on background */
 };
 
 /** The maximum allowed length of an AT command/response passed through the Serial Modem */

--- a/app/src/sm_ppp.c
+++ b/app/src/sm_ppp.c
@@ -25,6 +25,10 @@
 
 LOG_MODULE_REGISTER(sm_ppp, CONFIG_SM_LOG_LEVEL);
 
+#define CONNECT "\r\nCONNECT\r\n"
+#define NO_CARRIER "\r\nNO CARRIER\r\n"
+#define PDN_ACTIVATION_TIMEOUT K_SECONDS(30)
+
 /* This keeps track of whether the user is registered to the CGEV notifications.
  * We need them to know when to start/stop the PPP link, but that should not
  * influence what the user receives, so we do the filtering based on this.
@@ -40,8 +44,11 @@ static struct sockaddr_ll ppp_zephyr_dst_addr;
 static struct modem_pipe *ppp_pipe;
 static struct modem_pipe *ppp_urc_pipe;
 static struct k_thread ppp_data_passing_thread_id;
+static k_timepoint_t ppp_pdn_timeout;
 static K_THREAD_STACK_DEFINE(ppp_data_passing_thread_stack, KB(2));
 static void ppp_data_passing_thread(void*, void*, void*);
+static void sm_ppp_activate_pdp_dwork_fn(struct k_work *work);
+static K_WORK_DELAYABLE_DEFINE(activate_pdp_dwork,  sm_ppp_activate_pdp_dwork_fn);
 
 enum ppp_action {
 	PPP_START,
@@ -435,6 +442,47 @@ static int ppp_stop(enum ppp_reason reason)
 	return 0;
 }
 
+static void ppp_cmd_fail_return_to_at_mode(void)
+{
+	if (!ppp_pipe) {
+		return;
+	}
+	rsp_send_to(ppp_pipe, NO_CARRIER);
+	cmd_done(ppp_pipe);
+	ppp_pipe = NULL;
+}
+
+static void sm_ppp_activate_pdp_dwork_fn(struct k_work *work)
+{
+	if (!sm_util_cereg_is_registered()) {
+		if (sys_timepoint_expired(ppp_pdn_timeout)) {
+			LOG_ERR("Timeout while waiting for network registration");
+			ppp_cmd_fail_return_to_at_mode();
+			return;
+		}
+		k_work_reschedule_for_queue(&sm_work_q, &activate_pdp_dwork, K_SECONDS(1));
+		return;
+	}
+
+	if (!sm_util_is_cid_active(ppp_pdn_cid)) {
+		LOG_DBG("Activating PDP context %u for PPP...", ppp_pdn_cid);
+		int ret = sm_util_at_printf("AT+CGACT=1,%u", ppp_pdn_cid);
+
+		if (ret) {
+			LOG_ERR("Failed to activate PDP context %u for PPP (%d).", ppp_pdn_cid,
+				ret);
+			ppp_cmd_fail_return_to_at_mode();
+			return;
+		}
+	}
+	LOG_DBG("PDP context %u activated for PPP.", ppp_pdn_cid);
+	rsp_send_to(ppp_pipe, CONNECT);
+	sm_at_host_release(sm_at_host_get_ctx_from(ppp_pipe));
+	modem_ppp_attach(&ppp_module, ppp_pipe);
+	sm_ppp_set_auto_start(true);
+	delegate_ppp_event(PPP_START, PPP_REASON_CMD);
+}
+
 /* We need to receive CGEV notifications at all times.
  * CGEREP AT commands are intercepted to prevent the user
  * from unsubcribing us and make that behavior invisible.
@@ -773,6 +821,10 @@ static int handle_at_cgdata(enum at_parser_cmd_type cmd_type, struct at_parser *
 		return -EALREADY;
 	}
 
+	if (!sm_util_cfun_is_lte_enabled()) {
+		return -ENOTCONN;
+	}
+
 	if (ppp_pipe) {
 		sm_ppp_detach();
 	}
@@ -788,12 +840,10 @@ static int handle_at_cgdata(enum at_parser_cmd_type cmd_type, struct at_parser *
 	ppp_pipe = pipe;
 	sm_ppp_keep_pipe_attached = false;
 	ppp_pdn_cid = cid;
-	rsp_send("\r\nCONNECT\r\n");
-	sm_at_host_release(ctx);
-	modem_ppp_attach(&ppp_module, ppp_pipe);
-	sm_ppp_set_auto_start(true);
-	delegate_ppp_event(PPP_START, PPP_REASON_CMD);
-	return -SILENT_AT_COMMAND_RET;
+	/* Do not block the sm_work_q while waiting for PDP context activation */
+	ppp_pdn_timeout = sys_timepoint_calc(PDN_ACTIVATION_TIMEOUT);
+	(void) k_work_reschedule_for_queue(&sm_work_q, &activate_pdp_dwork, K_NO_WAIT);
+	return -AT_COMMAND_CONTINUE_RET;
 }
 
 static void ppp_data_passing_thread(void*, void*, void*)

--- a/app/src/sm_util.c
+++ b/app/src/sm_util.c
@@ -463,3 +463,64 @@ int sm_util_pdn_dynamic_info_get(uint8_t cid, struct sm_pdn_dynamic_info *pdn_in
 
 	return 0;
 }
+
+int sm_util_cfun_get(void)
+{
+	int ret;
+	int cfun_mode;
+
+	ret = sm_util_at_scanf("AT+CFUN?", "+CFUN: %d", &cfun_mode);
+	if (ret < 0) {
+		LOG_ERR("Failed to get CFUN mode, err %d", ret);
+		return ret;
+	}
+
+	return cfun_mode;
+}
+
+bool sm_util_cfun_is_lte_enabled(void)
+{
+	int cfun_mode = sm_util_cfun_get();
+
+	if (cfun_mode < 0) {
+		return false;
+	}
+
+	return (cfun_mode == LTE_LC_FUNC_MODE_NORMAL || cfun_mode == LTE_LC_FUNC_MODE_ACTIVATE_LTE);
+}
+
+int sm_util_cereg_get(void)
+{
+	int ret;
+	int creg_stat;
+
+	ret = sm_util_at_scanf("AT+CEREG?", "+CEREG: %*d,%d", &creg_stat);
+	if (ret < 0) {
+		LOG_ERR("Failed to get CEREG status, err %d", ret);
+		return ret;
+	}
+
+	return creg_stat;
+}
+
+bool sm_util_cereg_is_registered(void)
+{
+	int creg_stat = sm_util_cereg_get();
+
+	return (creg_stat == 1 || creg_stat == 5);
+}
+
+bool sm_util_is_cid_active(uint8_t cid)
+{
+	int ret;
+	char at_cmd_buf[sizeof("AT+CGPADDR=###")];
+	int active_cid;
+
+	(void)snprintf(at_cmd_buf, sizeof(at_cmd_buf), "AT+CGPADDR=%u", cid);
+	ret = sm_util_at_scanf(at_cmd_buf, "+CGPADDR: %d", &active_cid);
+	if (ret == 1 && active_cid == cid) {
+		return true;
+	}
+
+	return false;
+}

--- a/app/src/sm_util.h
+++ b/app/src/sm_util.h
@@ -224,6 +224,48 @@ static inline bool sm_pipe_is_open(struct modem_pipe *pipe)
 	       Z_MODEM_PIPE_EVENT_OPENED_BIT;
 }
 
+/**
+ * @brief Get the current functional mode of the modem
+ *
+ * @return value from AT+CFUN? or a negative error code on failure
+ */
+int sm_util_cfun_get(void);
+
+/**
+ * @brief Check if modem is in functional mode that allows LTE connectivity
+ *
+ * @return true if modem is in functional mode 1 (normal) or 21 (LTE is activated).
+ * @return false otherwise
+ */
+bool sm_util_cfun_is_lte_enabled(void);
+
+/**
+ * @brief Get the current network registration status of the modem
+ *
+ * @return value from AT+CEREG? or a negative error code on failure
+ */
+int sm_util_cereg_get(void);
+
+/**
+ * @brief Check if modem is registered to a cellular network
+ *
+ * @return true if registered or roaming
+ * @return false if not registered
+ */
+bool sm_util_cereg_is_registered(void);
+
+/**
+ * @brief Check if a PDP context is active
+ *
+ * Use AT+CGPADDR=<cid> to check if the given PDP context have valid address(es),
+ * which is an indication of whether the PDP context is active or not.
+ *
+ * @param[in] cid The PDP context ID.
+ * @return true if the PDP context is active
+ * @return false if the PDP context is not active
+ */
+bool sm_util_is_cid_active(uint8_t cid);
+
 /** @} */
 
 #endif /* SM_UTIL_ */


### PR DESCRIPTION
As defined in 3GPP 27.007:
```
10.1.12 Enter data state +CGDATA 

The execution command causes the MT to perform whatever actions are
necessary to establish communication between the TE and the network
using one or more Packet Domain PDP types.
This may include performing a PS attach and one or more PDP context
activations.
```

Add functionality to sm_ppp.c so that AT+CGDATA calls AT+CGACT if
the given CID is not yet connected.

This functionality required few extra helpers:
* [Allow AT command to continue execution after returning](https://github.com/nrfconnect/ncs-serial-modem/commit/24d4bb50925a2ca30911dcecbea2fd1be3b30059)
* [app: Add utility functions to check CFUN and CID statuses](https://github.com/nrfconnect/ncs-serial-modem/commit/4c6a6c77bf8158e2fc62fd7a9d28cacd839cc508)

Required by PR #261 