### PR TITLE
app: Fix byte count reported after HTTP request cancellation

### DIFF
--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -444,6 +444,12 @@ static void http_send_status(struct http_request *req)
 		 req->total_received);
 }
 
+/* Send cancel status URC with bytes already delivered to host */
+static void http_send_cancel_status(struct http_request *req)
+{
+	urc_send_to(req->pipe, "\r\n#XHTTPCSTAT: %d,-1,%d\r\n", req->fd, req->bytes_sent);
+}
+
 /* Send error and close request */
 static void http_fail_request(struct http_request *req)
 {
@@ -1354,7 +1360,8 @@ STATIC int handle_at_httpccancel(enum at_parser_cmd_type cmd_type, struct at_par
 		req = find_request(socket_fd);
 		if (req) {
 			LOG_INF("Cancelling HTTP request fd=%d", socket_fd);
-			http_fail_request(req);
+			http_send_cancel_status(req);
+			http_close_request(req);
 			k_mutex_unlock(&http_mutex);
 		} else {
 			k_mutex_unlock(&http_mutex);

--- a/doc/app/at_httpc.rst
+++ b/doc/app/at_httpc.rst
@@ -133,7 +133,8 @@ The notification line is terminated with ``\r\n`` and the raw body bytes follow 
 * The ``<status_code>`` parameter is an integer.
   It contains the HTTP status code on success, or ``-1`` on failure, cancel, or timeout.
 * The ``<total_bytes>`` parameter is an integer.
-  It contains the total number of body bytes received.
+   On successful completion, failure, or timeout, it contains the total number of response body bytes received by the HTTP client.
+   On cancel (``status_code=-1`` from ``AT#XHTTPCCANCEL``), it contains the number of response body bytes already delivered to the host.
 
 .. note::
 
@@ -399,7 +400,7 @@ Syntax
 * The ``<socket_fd>`` parameter is an integer.
   It identifies the socket of the request to cancel.
 
-An unsolicited ``#XHTTPCSTAT: <socket_fd>,-1,<total_bytes>`` notification is emitted after cancellation.
+An unsolicited ``#XHTTPCSTAT: <socket_fd>,-1,<total_bytes>`` notification is emitted after cancellation, where ``<total_bytes>`` is the number of response body bytes already delivered to the host.
 
 Example
 ~~~~~~~


### PR DESCRIPTION
Previously, `XHTTPCSTAT` reported `total_received` bytes, which could vary depending on timing. Replace the value with `bytes_sent`, which reflects the number of bytes the host has actually read at the point of cancellation.