### PR TITLE
Increase timeout for AT+CFUN=1

### DIFF
--- a/app/scripts/sm2_ppp_dial.chat
+++ b/app/scripts/sm2_ppp_dial.chat
@@ -20,7 +20,7 @@ ABORT +CNEC_ESM:
 #
 # Check AT channel
 #
-TIMEOUT 1
+TIMEOUT 10
 ''
 AT OK
 


### PR DESCRIPTION
One second is too tight for some SIM cards and environments. Raising the timeout makes the script more robust.