### PR TITLE
app: scripts: Add a bit more room time for device boot

### DIFF
--- a/app/scripts/sm2_ppp_dial.chat
+++ b/app/scripts/sm2_ppp_dial.chat
@@ -21,7 +21,7 @@ ABORT +CNEC_ESM:
 #
 # Check AT channel
 #
-TIMEOUT 1
+TIMEOUT 2
 ''
 AT OK
 


### PR DESCRIPTION
Change timeout for "AT" "OK" to 2s in case device just booted up.