### PR TITLE
manifest: Update nrf to 2026.03.25 upmerge

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,7 +13,7 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v3.3.0-rc1
+      revision: 0ab86fab0c9cc5e03171982de191521dc15961b7
       import:
         name-allowlist:
           - cjson


### PR DESCRIPTION
Update sdk-nrf and adapt to the 2026.03.25 upmerge: https://github.com/nrfconnect/sdk-nrf/pull/27726
This sdk-nrf is beyond v3.3.0 and few commits after above upmerge.

This had minimal memory impact on nRF91M1 configuration. Before:
```
           FLASH:      340652 B       440 KB     75.61%
             RAM:      151456 B     189208 B     80.05%

```
After:
```
           FLASH:      341320 B       440 KB     75.75%
             RAM:      151432 B     189208 B     80.03%
```

