### PR TITLE
app: at: Backspace not added to AT command

### DIFF
--- a/app/src/sm_at_host.c
+++ b/app/src/sm_at_host.c
@@ -1272,7 +1272,7 @@ static size_t cmd_rx_handler(struct sm_at_host_ctx *ctx, uint8_t c)
 		} else {
 			ctx->prev_character = '\0';
 		}
-		break;
+		goto handle_echo;
 	default:
 		break;
 	}


### PR DESCRIPTION
Delete (0x7D) used to delete previous character but delete byte 0x7D was added to AT command buffer resulting in syntax error.
Delete is not added to the AT command anymore.

This looks like regression from PR #133.

PS. 0x7F is delete character in ASCII. This is what my few terminals I've tried will send when pressing backspace.

Jira: SM-330