### PR TITLE
app: log_flush called when log backend initialized

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -19,6 +19,7 @@
 #include "sm_util.h"
 #include "sm_ctrl_pin.h"
 #include "sm_uart_handler.h"
+#include "sm_log.h"
 
 LOG_MODULE_REGISTER(sm, CONFIG_SM_LOG_LEVEL);
 
@@ -291,7 +292,7 @@ static int sm_main(void)
 	return ret;
 
 exit_reboot:
-	log_flush();
+	sm_log_flush();
 	sys_reboot(SYS_REBOOT_COLD);
 }
 SYS_INIT(sm_main, APPLICATION, 100);

--- a/app/src/sm_at_commands.c
+++ b/app/src/sm_at_commands.c
@@ -31,6 +31,7 @@
 #include "sm_at_fota.h"
 #include "sm_version.h"
 #include "sm_at_nrfcloud.h"
+#include "sm_log.h"
 
 LOG_MODULE_REGISTER(sm_at, CONFIG_SM_LOG_LEVEL);
 
@@ -161,7 +162,7 @@ FUNC_NORETURN void sm_reset(void)
 {
 	sm_at_host_uninit();
 	sm_power_off_modem();
-	log_flush();
+	sm_log_flush();
 	sys_reboot(SYS_REBOOT_COLD);
 }
 

--- a/app/src/sm_at_dfu.c
+++ b/app/src/sm_at_dfu.c
@@ -22,6 +22,7 @@
 #include "sm_at_dfu.h"
 #include "sm_settings.h"
 #include "sm_uart_handler.h"
+#include "sm_log.h"
 
 LOG_MODULE_REGISTER(sm_dfu, CONFIG_SM_LOG_LEVEL);
 
@@ -331,7 +332,7 @@ static int handle_at_xdfu_init(enum at_parser_cmd_type cmd_type, struct at_parse
 
 			(void)set_full_mfw_dfu_segment_type(DFU_FULL_MFW_SEGMENT_BOOTLOADER);
 
-			log_flush();
+			sm_log_flush();
 			sys_reboot(SYS_REBOOT_COLD);
 		default:
 			LOG_ERR("Invalid target type: %d", type);
@@ -622,7 +623,7 @@ static int handle_at_xdfu_apply(enum at_parser_cmd_type cmd_type, struct at_pars
 					(void)set_full_mfw_dfu_segment_type(
 						DFU_FULL_MFW_SEGMENT_BOOTLOADER);
 					LOG_INF("Firmware update successful, rebooting...");
-					log_flush();
+					sm_log_flush();
 					sys_reboot(SYS_REBOOT_COLD);
 				}
 			}

--- a/app/src/sm_at_fota.c
+++ b/app/src/sm_at_fota.c
@@ -24,6 +24,7 @@
 #include "sm_at_host.h"
 #include "sm_at_fota.h"
 #include "sm_defines.h"
+#include "sm_log.h"
 
 LOG_MODULE_REGISTER(sm_fota, CONFIG_SM_LOG_LEVEL);
 
@@ -582,7 +583,7 @@ FUNC_NORETURN static void handle_full_fota_activation_fail(int ret)
 		LOG_INF("External flash erase succeeded");
 
 	LOG_WRN("Rebooting...");
-	log_flush();
+	sm_log_flush();
 	sys_reboot(SYS_REBOOT_COLD);
 }
 

--- a/app/src/sm_at_host.c
+++ b/app/src/sm_at_host.c
@@ -2108,7 +2108,6 @@ SYS_INIT(sm_at_host_init, APPLICATION, 0);
 void sm_at_host_uninit(void)
 {
 	/* TODO: implement this */
-	LOG_ERR("at_host uninit not yet implemented");
 }
 
 SM_AT_CMD_CUSTOM(xdatactrl, "AT#XDATACTRL", handle_at_datactrl);

--- a/app/src/sm_ctrl_pin.c
+++ b/app/src/sm_ctrl_pin.c
@@ -15,6 +15,7 @@
 #include "sm_defines.h"
 #include "sm_util.h"
 #include "sm_ctrl_pin.h"
+#include "sm_log.h"
 
 LOG_MODULE_REGISTER(sm_ctrl_pin, CONFIG_SM_LOG_LEVEL);
 
@@ -101,7 +102,7 @@ void sm_ctrl_pin_enter_sleep_no_uninit(bool at_host_power_off)
 	}
 
 	LOG_INF("Entering sleep. No uninit.");
-	log_flush();
+	sm_log_flush();
 
 	k_sleep(K_MSEC(100));
 
@@ -155,7 +156,7 @@ void sm_ctrl_pin_enter_idle(void)
 void sm_ctrl_pin_enter_shutdown(void)
 {
 	LOG_INF("Entering shutdown.");
-	log_flush();
+	sm_log_flush();
 	k_sleep(K_MSEC(100));
 
 	nrf_regulators_system_off(NRF_REGULATORS_NS);

--- a/app/src/sm_log.c
+++ b/app/src/sm_log.c
@@ -69,6 +69,15 @@ static bool uart_is_active(void)
 	return state == PM_DEVICE_STATE_ACTIVE;
 }
 
+void sm_log_flush(void)
+{
+	const struct log_backend *log_be = log_backend_get_by_name("log_backend_uart");
+
+	if (log_be && log_be->cb && log_be->cb->initialized) {
+		log_flush();
+	}
+}
+
 SM_AT_CMD_CUSTOM(xlog, "AT#XLOG", handle_at_log);
 STATIC int handle_at_log(enum at_parser_cmd_type cmd_type, struct at_parser *parser, uint32_t)
 {

--- a/app/src/sm_log.h
+++ b/app/src/sm_log.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef SM_LOG_
+#define SM_LOG_
+
+/**@file sm_log.h
+ *
+ * @brief Log functions for Serial Modem
+ * @{
+ */
+
+void sm_log_flush(void);
+
+/** @} */
+
+#endif /* SM_LOG_ */

--- a/app/tests/at_commands/CMakeLists.txt
+++ b/app/tests/at_commands/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(app PRIVATE
   ../stubs/tfm_stubs.c
   ../stubs/at_cmd_custom_stubs.c
   ../stubs/sm_workq.c
+  ../stubs/sm_log_stubs.c
   ../../src/sm_util.c
   ../../src/sm_at_commands.c
   ../../src/sm_at_host.c

--- a/app/tests/at_socket/CMakeLists.txt
+++ b/app/tests/at_socket/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(app PRIVATE
   ../stubs/tfm_stubs.c
   ../stubs/at_cmd_custom_stubs.c
   ../stubs/sm_workq.c
+  ../stubs/sm_log_stubs.c
   ../../src/sm_util.c
   ../../src/sm_at_socket.c
   ../../src/sm_at_host.c

--- a/app/tests/stubs/sm_log_stubs.c
+++ b/app/tests/stubs/sm_log_stubs.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+void sm_log_flush(void)
+{
+	/* Stub - no-op for tests */
+}


### PR DESCRIPTION
log_flush() can only be called when log backend has been initialized.

Jira: SM-304