### PR TITLE
workflows: build: Fix artifact folder and add artifacts to manually triggered builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,8 @@ jobs:
           mkdir -p artifacts
           mkdir -p artifacts_extras
           VERSION=${{ github.event.release.tag_name || github.ref_name || 'unknown-version' }}
-          NRF9151DK_DIR=twister-out/nrf9151dk_nrf9151_ns/zephyr/serial_modem/app
-          NRF54L15DK_DIR=twister-out/nrf54l15dk_nrf54l15_cpuapp/zephyr/serial_modem/samples
+          NRF9151DK_DIR=twister-out/nrf9151dk_nrf9151_ns/zephyr_gnu/serial_modem/app
+          NRF54L15DK_DIR=twister-out/nrf54l15dk_nrf54l15_cpuapp/zephyr_gnu/serial_modem/samples
 
           # Create release bundle: merged.hex, Kconfig, signed images, elf, DFU zip
           zip_artifacts() {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,12 +76,12 @@ jobs:
           ./nrfutil toolchain-manager launch --chdir serial_modem -- west twister -T . -v --inline-logs --overflow-as-errors --integration --exclude-tag exclude_integration
 
       - name: Build Serial Modem nightly
-        if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' }}
+        if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}
         run: |
           ./nrfutil toolchain-manager launch --chdir serial_modem -- west twister -T . -v --inline-logs --overflow-as-errors --all
 
       - name: Zip build artifacts
-        if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' }}
+        if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}
         working-directory: serial_modem
         run: |
           mkdir -p artifacts
@@ -135,14 +135,14 @@ jobs:
           zip_artifacts "sm_ppp_shell" "${NRF54L15DK_DIR}/sm_ppp_shell/sample.sm_ppp_shell" "sm_ppp_shell_${VERSION}_nrf54l15dk" 1
 
       - name: Upload artifacts
-        if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' }}
+        if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v4
         with:
           path: |
             serial_modem/artifacts/*
 
       - name: Upload artifact extras
-        if: ${{ inputs.trigger_source == 'release-workflow' }}
+        if: ${{ inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v4
         with:
           name: artifact_extras


### PR DESCRIPTION
Two changes:
* In 2026.03.25 upmerge, twister output folder structure changed from zephyr -> zephyr_gnu in twister-out/nrf9151dk_nrf9151_ns/zephyr_gnu/serial_modem/app
* When the build is triggered manually from github actions UI, nothing was built. Perform the build and upload artifacts and extras.