### PR TITLE
workflows: build: Store MCUboot update binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           ./nrfutil toolchain-manager launch --chdir serial_modem -- west twister -T . -v --inline-logs --overflow-as-errors --all
 
       - name: Zip build artifacts
-        if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}
         working-directory: serial_modem
         run: |
           mkdir -p artifacts
@@ -106,12 +106,15 @@ jobs:
             cp "${src_dir}/${app_build_dir}/zephyr/zephyr.dts" "${temp}/${base}.dts"
             if [ -z "$host" ]; then
               cp "${src_dir}/${app_build_dir}/zephyr/zephyr.signed.bin" "${temp}/${base}.signed.bin"
-              cp "${src_dir}/dfu_application.zip" "${temp}/${base}_dfu.zip"
+              cp "${src_dir}/dfu_application.zip" "${temp}/${base}_dfu_application.zip"
+              cp "${src_dir}/dfu_mcuboot.zip" "${temp}/${base}_dfu_mcuboot.zip"
+              cp "${src_dir}/signed_by_mcuboot_and_b0_mcuboot.bin" "${temp}/${base}_mcuboot_s0.signed.bin"
+              cp "${src_dir}/signed_by_mcuboot_and_b0_s1_image.bin" "${temp}/${base}_mcuboot_s1.signed.bin"
             fi
             (cd "$temp" && zip -q -r "$root/artifacts/${base}.zip" .)
 
             cd ${src_dir}
-            find . -type f \( -name '*.elf' -o -name '*.dts' -o -name '.config' \) -exec zip -q -r "${root}/artifacts_extras/${base}_extras.zip" {} +
+            find . -type f \( -name '*.elf' -o -name '*.dts' -o -name '.config' -o -name '*.bin' -o -name '*.hex' \) -exec zip -q -r "${root}/artifacts_extras/${base}_extras.zip" {} +
             cd ${root}
 
             rm -rf "$temp"
@@ -135,7 +138,7 @@ jobs:
           zip_artifacts "sm_ppp_shell" "${NRF54L15DK_DIR}/sm_ppp_shell/sample.sm_ppp_shell" "sm_ppp_shell_${VERSION}_nrf54l15dk" 1
 
       - name: Upload artifacts
-        if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v4
         with:
           path: |

--- a/doc/releases/release_artifacts.rst
+++ b/doc/releases/release_artifacts.rst
@@ -39,8 +39,14 @@ The artifacts are zipped and contain build files such as:
      - The unsigned application binary (MCUboot + application) to be flashed with Programmer or nRF Util.
    * - ``.signed.bin``
      - Signed application only binary to be used in FOTA/DFU.
-   * - ``_dfu.zip``
+   * - ``_mcuboot_s0.signed.bin``
+     - Signed MCUboot binary for S0 slot to be used in FOTA/DFU.
+   * - ``_mcuboot_s1.signed.bin``
+     - Signed MCUboot binary for S1 slot to be used in FOTA/DFU.
+   * - ``_dfu_application.zip``
      - Signed application only binary zipped with metadata used by nRF Cloud for FOTA/DFU.
+   * - ``_dfu_mcuboot.zip``
+     - Signed MCUboot binary for S0 and S1 slots zipped with metadata used by nRF Cloud for FOTA/DFU.
    * - ``.elf``
      - Application image symbols for debugging purposes.
    * - ``.dts``


### PR DESCRIPTION
Store MCUboot update images when collecting artifacts.
Add all `*.bin` and `*.hex` files into extra artifacts to be collected for releases and manually triggered workflows.
Remove basic artifact upload from nightly builds at least until we use them. If we need them, we can trigger the build manually.