### PR TITLE
app: Move from nrf_ to zsock_ socket operations

### DIFF
--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/net/http/parser_url.h>
 #include <nrf_socket.h>
+#include <zephyr/net/socket.h>
 #include <modem/at_parser.h>
 #include <stdio.h>
 #include <string.h>
@@ -374,7 +375,7 @@ static int http_start_request(struct http_request *req)
 		return -EINVAL;
 	}
 
-	ret = set_xapoll_events(sock, NRF_POLLOUT | NRF_POLLIN);
+	ret = set_xapoll_events(sock, ZSOCK_POLLOUT | ZSOCK_POLLIN);
 	if (ret) {
 		LOG_ERR("Failed to set XAPOLL events: %d", ret);
 		return ret;
@@ -692,12 +693,12 @@ static int http_recv_read(struct http_request *req, struct sm_socket *sock)
 {
 	int ret;
 
-	ret = nrf_recv(req->fd, req->recv_buf + req->recv_buf_len,
-		       HTTP_RECV_BUF_SIZE - req->recv_buf_len - 1, NRF_MSG_DONTWAIT);
+	ret = zsock_recv(req->fd, req->recv_buf + req->recv_buf_len,
+		       HTTP_RECV_BUF_SIZE - req->recv_buf_len - 1, MSG_DONTWAIT);
 
 	if (ret < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {
-			set_xapoll_events(sock, NRF_POLLIN);
+			set_xapoll_events(sock, ZSOCK_POLLIN);
 			return -1;
 		}
 		if (errno == ETIMEDOUT) {
@@ -726,7 +727,7 @@ static void http_process_recv_headers(struct http_request *req, struct sm_socket
 	char *header_end = strstr((char *)req->recv_buf, "\r\n\r\n");
 
 	if (header_end) {
-		if (http_headers_complete(req, header_end, sock, events & NRF_POLLHUP)) {
+		if (http_headers_complete(req, header_end, sock, events & ZSOCK_POLLHUP)) {
 			return;
 		}
 		req->need_rearm_pollin = true;
@@ -750,7 +751,7 @@ static void http_process_recv_body(struct http_request *req, struct sm_socket *s
 	if (req->manual_mode) {
 		/*
 		 * POLLIN fired in body state after xapoll_stop (race).
-		 * nrf_recv already consumed bytes from the socket buffer
+		 * zsock_recv already consumed bytes from the socket buffer
 		 * into recv_buf and incremented total_received. Keep
 		 * recv_buf intact so the host can pull it; do NOT reset
 		 * recv_buf_len or the data is silently lost.
@@ -767,7 +768,7 @@ static void http_process_recv_body(struct http_request *req, struct sm_socket *s
 	/* Finish if content-length satisfied, chunked EOF, or connection closing. */
 	if (body_done ||
 	    (req->content_length > 0 && req->bytes_sent >= req->content_length) ||
-	    (events & NRF_POLLHUP)) {
+	    (events & ZSOCK_POLLHUP)) {
 		http_finish_request(req);
 		return;
 	}
@@ -791,14 +792,14 @@ static void http_process_request(struct http_request *req, uint8_t events)
 		req->state, events, k_uptime_get(), req->timeout_timestamp);
 
 	/* POLLERR/POLLNVAL are always fatal; POLLHUP is handled per-state below. */
-	if (events & (NRF_POLLERR | NRF_POLLNVAL)) {
+	if (events & (ZSOCK_POLLERR | ZSOCK_POLLNVAL)) {
 		LOG_ERR("HTTP %d: Socket error (events=0x%x)", req->fd, events);
 		http_fail_request(req);
 		return;
 	}
 
 	/* POLLHUP during sending means the server closed the connection unexpectedly. */
-	if ((events & NRF_POLLHUP) && req->state == HTTP_STATE_SENDING_REQUEST) {
+	if ((events & ZSOCK_POLLHUP) && req->state == HTTP_STATE_SENDING_REQUEST) {
 		LOG_ERR("HTTP %d: Connection closed during send (events=0x%x)", req->fd,
 			events);
 		http_fail_request(req);
@@ -808,14 +809,14 @@ static void http_process_request(struct http_request *req, uint8_t events)
 	switch (req->state) {
 	case HTTP_STATE_SENDING_REQUEST:
 		/* Handle writable socket */
-		if (events & NRF_POLLOUT) {
-			ret = nrf_send(req->fd, req->send_ptr, req->send_remaining,
-				       NRF_MSG_DONTWAIT);
+		if (events & ZSOCK_POLLOUT) {
+			ret = zsock_send(req->fd, req->send_ptr, req->send_remaining,
+				       MSG_DONTWAIT);
 
 			if (ret < 0) {
 				if (errno == EAGAIN || errno == EWOULDBLOCK) {
 					/* Need to wait for next POLLOUT */
-					set_xapoll_events(sock, NRF_POLLOUT | NRF_POLLIN);
+					set_xapoll_events(sock, ZSOCK_POLLOUT | ZSOCK_POLLIN);
 					return;
 				}
 				LOG_ERR("Send failed: %d", errno);
@@ -830,10 +831,10 @@ static void http_process_request(struct http_request *req, uint8_t events)
 				/* All headers sent, now wait for response */
 				req->state = HTTP_STATE_RECEIVING_HEADERS;
 				req->recv_buf_len = 0;
-				set_xapoll_events(sock, NRF_POLLIN);
+				set_xapoll_events(sock, ZSOCK_POLLIN);
 			} else {
 				/* More to send */
-				set_xapoll_events(sock, NRF_POLLOUT | NRF_POLLIN);
+				set_xapoll_events(sock, ZSOCK_POLLOUT | ZSOCK_POLLIN);
 			}
 		}
 		break;
@@ -843,14 +844,14 @@ static void http_process_request(struct http_request *req, uint8_t events)
 		 * POLLHUP without POLLIN: closed before any response. When POLLIN
 		 * arrives at the same time, drain the socket buffer (e.g. Connection: close).
 		 */
-		if ((events & NRF_POLLHUP) && !(events & NRF_POLLIN)) {
+		if ((events & ZSOCK_POLLHUP) && !(events & ZSOCK_POLLIN)) {
 			LOG_ERR("HTTP %d: Connection closed before headers (POLLHUP)",
 				req->fd);
 			http_fail_request(req);
 			return;
 		}
 
-		if (!(events & NRF_POLLIN)) {
+		if (!(events & ZSOCK_POLLIN)) {
 			return;
 		}
 
@@ -871,13 +872,13 @@ static void http_process_request(struct http_request *req, uint8_t events)
 
 	case HTTP_STATE_RECEIVING_BODY:
 		/* POLLHUP alone: server closed cleanly after sending body. */
-		if ((events & NRF_POLLHUP) && !(events & NRF_POLLIN)) {
+		if ((events & ZSOCK_POLLHUP) && !(events & ZSOCK_POLLIN)) {
 			http_warn_incomplete_transfer(req);
 			http_finish_request(req);
 			return;
 		}
 
-		if (!(events & NRF_POLLIN)) {
+		if (!(events & ZSOCK_POLLIN)) {
 			return;
 		}
 
@@ -948,7 +949,7 @@ static int http_send_request_headers(struct http_request *req)
 	/* Send headers synchronously (blocking) */
 	sent = 0;
 	while (sent < ret) {
-		n = nrf_send(req->fd, req->send_buf + sent, ret - sent, 0);
+		n = zsock_send(req->fd, req->send_buf + sent, ret - sent, 0);
 		if (n < 0) {
 			return -errno;
 		}
@@ -983,7 +984,7 @@ static int http_datamode_callback(uint8_t op, const uint8_t *data, int len, uint
 		int sent = 0;
 
 		while (sent < len) {
-			int ret = nrf_send(datamode_req->fd, data + sent, len - sent, 0);
+			int ret = zsock_send(datamode_req->fd, data + sent, len - sent, 0);
 
 			if (ret < 0) {
 				int err_code = -errno;
@@ -1026,7 +1027,7 @@ static int http_datamode_callback(uint8_t op, const uint8_t *data, int len, uint
 					datamode_req->recv_buf_len = 0;
 					datamode_req->timeout_timestamp =
 						k_uptime_get() + HTTP_RESPONSE_TIMEOUT_MS;
-					err = set_xapoll_events(sock, NRF_POLLIN);
+					err = set_xapoll_events(sock, ZSOCK_POLLIN);
 					if (err) {
 						LOG_ERR("Failed to arm XAPOLL: %d", err);
 						http_fail_request(datamode_req);
@@ -1339,7 +1340,7 @@ static int pull_data(int socket_fd, int pull_len)
 	}
 
 	/* Do one non-blocking recv and send to host */
-	ret = nrf_recv(req->fd, req->recv_buf, pull_len, NRF_MSG_DONTWAIT);
+	ret = zsock_recv(req->fd, req->recv_buf, pull_len, MSG_DONTWAIT);
 
 	if (ret < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {

--- a/app/src/sm_at_httpc.h
+++ b/app/src/sm_at_httpc.h
@@ -20,7 +20,7 @@
  * @brief Notify HTTP client of poll events (called from socket layer)
  *
  * @param fd Socket file descriptor
- * @param events Poll events (NRF_POLLIN, etc.)
+ * @param events Poll events (ZSOCK_POLLIN, etc.)
  * @return true if HTTP client needs POLLIN re-armed after callback
  */
 bool sm_at_httpc_poll_event(int fd, uint8_t events);

--- a/app/src/sm_at_icmp.c
+++ b/app/src/sm_at_icmp.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <zephyr/net/socket.h>
-#include <nrf_socket.h>
 #include "sm_util.h"
 #include "sm_at_host.h"
 

--- a/app/src/sm_at_socket.c
+++ b/app/src/sm_at_socket.c
@@ -81,7 +81,7 @@ struct sm_send_ntf {
 };
 
 static struct sm_socket {
-	int type;                        /* NRF_SOCK_STREAM or NRF_SOCK_DGRAM */
+	int type;                        /* SOCK_STREAM or SOCK_DGRAM */
 	uint16_t role;                   /* Client or Server */
 	sec_tag_t sec_tag;               /* Security tag of the credential */
 	int family;                      /* Socket address family */
@@ -117,7 +117,7 @@ static void init_socket(struct sm_socket *socket)
 	socket->type = 0;
 	socket->role = AT_SOCKET_ROLE_CLIENT;
 	socket->sec_tag = SEC_TAG_TLS_INVALID;
-	socket->family = NRF_AF_UNSPEC;
+	socket->family = AF_UNSPEC;
 	socket->fd = INVALID_SOCKET;
 	socket->cid = 0;
 	socket->local_port = 0;
@@ -171,10 +171,10 @@ static int bind_to_pdn(struct sm_socket *sock)
 			return pdn_id;
 		}
 
-		ret = nrf_setsockopt(sock->fd, NRF_SOL_SOCKET, NRF_SO_BINDTOPDN, &pdn_id,
+		ret = zsock_setsockopt(sock->fd, SOL_SOCKET, SO_BINDTOPDN, &pdn_id,
 				     sizeof(int));
 		if (ret < 0) {
-			LOG_ERR("nrf_setsockopt(%d) error: %d", NRF_SO_BINDTOPDN, -errno);
+			LOG_ERR("zsock_setsockopt(%d) error: %d", SO_BINDTOPDN, -errno);
 			ret = -errno;
 		}
 	}
@@ -183,7 +183,7 @@ static int bind_to_pdn(struct sm_socket *sock)
 }
 
 /* Called in IRQ context */
-static void poll_cb(struct nrf_pollfd *pollfd)
+static void poll_cb(const struct socket_ncs_pollcb_params *pollfd)
 {
 	LOG_DBG("Poll event fd %d, revents 0x%x", pollfd->fd, pollfd->revents);
 
@@ -216,16 +216,16 @@ static int set_so_poll_cb(struct sm_socket *socket, uint8_t events)
 
 	LOG_DBG("Set poll cb for socket %d, events %d", socket->fd, events);
 
-	struct nrf_modem_pollcb pcb = {
+	struct socket_ncs_pollcb pcb = {
 		.callback = poll_cb,
 		.events = events,
 		.oneshot = true,
 	};
 
-	err = nrf_setsockopt(socket->fd, NRF_SOL_SOCKET, NRF_SO_POLLCB, &pcb, sizeof(pcb));
+	err = zsock_setsockopt(socket->fd, SOL_SOCKET, SO_POLLCB, &pcb, sizeof(pcb));
 	if (err < 0) {
-		LOG_ERR("nrf_setsockopt(%d,%d,%d) error: %d", socket->fd, NRF_SOL_SOCKET,
-			NRF_SO_POLLCB, -errno);
+		LOG_ERR("zsock_setsockopt(%d,%d,%d) error: %d", socket->fd, SOL_SOCKET,
+			SO_POLLCB, -errno);
 		return -errno;
 	}
 	return 0;
@@ -242,13 +242,13 @@ static void auto_reception(struct sm_socket *sock)
 		return;
 	}
 
-	if (sock->connected || sock->type == NRF_SOCK_RAW) {
-		err = do_recv(sock, 0, NRF_MSG_DONTWAIT,
+	if (sock->connected || sock->type == SOCK_RAW) {
+		err = do_recv(sock, 0, MSG_DONTWAIT,
 			      sock->async_poll.adr_hex ? AT_SOCKET_MODE_HEX
 						      : AT_SOCKET_MODE_UNFORMATTED,
 			      sizeof(sm_data_buf));
 	} else {
-		err = do_recvfrom(sock, 0, NRF_MSG_DONTWAIT,
+		err = do_recvfrom(sock, 0, MSG_DONTWAIT,
 				  sock->async_poll.adr_hex ? AT_SOCKET_MODE_HEX
 							  : AT_SOCKET_MODE_UNFORMATTED,
 				  sizeof(sm_data_buf));
@@ -381,29 +381,29 @@ void sm_at_socket_poll_work_handler(struct k_work *work)
 			}
 
 			/* If HTTP client requests POLLIN re-arm, restore it before clearing */
-			if (http_needs_rearm && (revents & NRF_POLLIN)) {
-				sock->async_poll.xapoll_events |= NRF_POLLIN;
-				sock->async_poll.events |= NRF_POLLIN;  /* MUST also restore */
+			if (http_needs_rearm && (revents & ZSOCK_POLLIN)) {
+				sock->async_poll.xapoll_events |= ZSOCK_POLLIN;
+				sock->async_poll.events |= ZSOCK_POLLIN;  /* MUST also restore */
 				/* Clear POLLIN from revents to prevent line 374 from clearing it
 				 * from events
 				 */
-				revents &= ~NRF_POLLIN;
+				revents &= ~ZSOCK_POLLIN;
 			}
 		}
 
 		/* Remove POLLOUT from poll, until send is done. */
-		if (revents & NRF_POLLOUT) {
-			sock->async_poll.events &= ~NRF_POLLOUT;
+		if (revents & ZSOCK_POLLOUT) {
+			sock->async_poll.events &= ~ZSOCK_POLLOUT;
 		}
 
 		/* Prevent further poll activations for socket. */
-		if (revents & (NRF_POLLERR | NRF_POLLNVAL | NRF_POLLHUP)) {
+		if (revents & (ZSOCK_POLLERR | ZSOCK_POLLNVAL | ZSOCK_POLLHUP)) {
 			sock->async_poll.disable = true;
 		}
 
 		/* Remove POLLIN from poll, until recv is done. */
-		if (revents & NRF_POLLIN) {
-			sock->async_poll.events &= ~NRF_POLLIN;
+		if (revents & ZSOCK_POLLIN) {
+			sock->async_poll.events &= ~ZSOCK_POLLIN;
 
 			/* Automatic data reception may reactivate POLLIN. */
 			if (((at_and_idle && (sock->async_poll.adr_flags & SM_ADR_AT_MODE)) ||
@@ -423,11 +423,11 @@ void sm_at_socket_poll_work_handler(struct k_work *work)
 		if (data_mode) {
 			int err = 0;
 
-			if (revents & NRF_POLLERR) {
+			if (revents & ZSOCK_POLLERR) {
 				err = -EIO;
-			} else if (revents & NRF_POLLNVAL) {
+			} else if (revents & ZSOCK_POLLNVAL) {
 				err = -ENETDOWN;
-			} else if (revents & NRF_POLLHUP) {
+			} else if (revents & ZSOCK_POLLHUP) {
 				err = -ECONNRESET;
 			}
 			if (err) {
@@ -455,13 +455,13 @@ static void send_cb_fn(struct k_work *work)
 			}
 			urc_send_to(socks[i].pipe, "\r\n#XSENDNTF: %d,%d,%d\r\n", socks[i].fd,
 				    status, bytes_sent);
-			update_poll_events(&socks[i], NRF_POLLOUT, true);
+			update_poll_events(&socks[i], ZSOCK_POLLOUT, true);
 		}
 	}
 }
 
 /* Called in IRQ context */
-static void send_cb(const struct nrf_modem_sendcb_params *params)
+static void send_cb(const struct socket_ncs_sendcb_params *params)
 {
 	static K_WORK_DEFINE(work, send_cb_fn);
 
@@ -499,14 +499,14 @@ static int set_so_send_cb(struct sm_socket *socket)
 
 	LOG_DBG("Set send cb for socket %d", socket->fd);
 
-	struct nrf_modem_sendcb pcb = {
+	struct socket_ncs_sendcb pcb = {
 		.callback = send_cb,
 	};
 
-	err = nrf_setsockopt(socket->fd, NRF_SOL_SOCKET, NRF_SO_SENDCB, &pcb, sizeof(pcb));
+	err = zsock_setsockopt(socket->fd, SOL_SOCKET, SO_SENDCB, &pcb, sizeof(pcb));
 	if (err < 0) {
-		LOG_ERR("nrf_setsockopt(%d,%d,%d) error: %d", socket->fd, NRF_SOL_SOCKET,
-			NRF_SO_SENDCB, -errno);
+		LOG_ERR("zsock_setsockopt(%d,%d,%d) error: %d", socket->fd, SOL_SOCKET,
+			SO_SENDCB, -errno);
 
 		return -errno;
 	}
@@ -529,10 +529,10 @@ static int clear_so_send_cb(struct sm_socket *socket)
 
 	LOG_DBG("Clear send cb for socket %d", socket->fd);
 
-	err = nrf_setsockopt(socket->fd, NRF_SOL_SOCKET, NRF_SO_SENDCB, NULL, 0);
+	err = zsock_setsockopt(socket->fd, SOL_SOCKET, SO_SENDCB, NULL, 0);
 	if (err < 0) {
-		LOG_ERR("nrf_setsockopt(%d,%d,%d) error: %d", socket->fd, NRF_SOL_SOCKET,
-			NRF_SO_SENDCB, -errno);
+		LOG_ERR("zsock_setsockopt(%d,%d,%d) error: %d", socket->fd, SOL_SOCKET,
+			SO_SENDCB, -errno);
 		err = -errno;
 	}
 
@@ -544,44 +544,44 @@ static int clear_so_send_cb(struct sm_socket *socket)
 static int do_socket_open(struct sm_socket *sock)
 {
 	int ret = 0;
-	int proto = NRF_IPPROTO_TCP;
+	int proto = IPPROTO_TCP;
 
-	if (sock->family != NRF_AF_INET && sock->family != NRF_AF_INET6 &&
-	    sock->family != NRF_AF_PACKET) {
+	if (sock->family != AF_INET && sock->family != AF_INET6 &&
+	    sock->family != AF_PACKET) {
 		LOG_ERR("Socket family %d not supported", sock->family);
 		return -ENOTSUP;
 	}
 
-	if (sock->type == NRF_SOCK_RAW || sock->family == NRF_AF_PACKET) {
-		if (sock->type != NRF_SOCK_RAW || sock->family != NRF_AF_PACKET)  {
+	if (sock->type == SOCK_RAW || sock->family == AF_PACKET) {
+		if (sock->type != SOCK_RAW || sock->family != AF_PACKET)  {
 			LOG_ERR("Raw socket: Family and type must match");
 			return -EINVAL;
 		}
 	}
 
-	if (sock->type == NRF_SOCK_STREAM) {
-		ret = nrf_socket(sock->family, NRF_SOCK_STREAM, NRF_IPPROTO_TCP);
-	} else if (sock->type == NRF_SOCK_DGRAM) {
-		ret = nrf_socket(sock->family, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP);
-		proto = NRF_IPPROTO_UDP;
-	} else if (sock->type == NRF_SOCK_RAW) {
-		ret = nrf_socket(sock->family, NRF_SOCK_RAW, NRF_IPPROTO_RAW);
-		proto = NRF_IPPROTO_IP;
+	if (sock->type == SOCK_STREAM) {
+		ret = zsock_socket(sock->family, SOCK_STREAM, IPPROTO_TCP);
+	} else if (sock->type == SOCK_DGRAM) {
+		ret = zsock_socket(sock->family, SOCK_DGRAM, IPPROTO_UDP);
+		proto = IPPROTO_UDP;
+	} else if (sock->type == SOCK_RAW) {
+		ret = zsock_socket(sock->family, SOCK_RAW, IPPROTO_RAW);
+		proto = IPPROTO_IP;
 	} else {
 		LOG_ERR("Socket type %d not supported", sock->type);
 		return -ENOTSUP;
 	}
 	if (ret < 0) {
-		LOG_ERR("nrf_socket() error: %d", -errno);
+		LOG_ERR("zsock_socket() error: %d", -errno);
 		return -errno;
 	}
 
 	sock->fd = ret;
 	struct timeval tmo = {.tv_sec = SOCKET_SEND_TMO_SEC};
 
-	ret = nrf_setsockopt(sock->fd, NRF_SOL_SOCKET, NRF_SO_SNDTIMEO, &tmo, sizeof(tmo));
+	ret = zsock_setsockopt(sock->fd, SOL_SOCKET, SO_SNDTIMEO, &tmo, sizeof(tmo));
 	if (ret) {
-		LOG_ERR("nrf_setsockopt(%d) error: %d", NRF_SO_SNDTIMEO, -errno);
+		LOG_ERR("zsock_setsockopt(%d) error: %d", SO_SNDTIMEO, -errno);
 		ret = -errno;
 		goto error;
 	}
@@ -605,12 +605,13 @@ static int do_socket_open(struct sm_socket *sock)
 	sock->async_poll.adr_hex = poll_ctx->adr_hex;
 	sock->async_poll.xapoll_events_requested = poll_ctx->xapoll_events_requested;
 	update_poll_events(
-		sock, NRF_POLLIN | NRF_POLLOUT | NRF_POLLERR | NRF_POLLHUP | NRF_POLLNVAL, true);
+		sock, ZSOCK_POLLIN | ZSOCK_POLLOUT | ZSOCK_POLLERR | ZSOCK_POLLHUP | ZSOCK_POLLNVAL,
+		true);
 
 	return 0;
 
 error:
-	nrf_close(sock->fd);
+	zsock_close(sock->fd);
 	sock->fd = INVALID_SOCKET;
 	return ret;
 }
@@ -618,30 +619,30 @@ error:
 static int do_secure_socket_open(struct sm_socket *sock, int peer_verify)
 {
 	int ret = 0;
-	int proto = sock->type == NRF_SOCK_STREAM ? NRF_SPROTO_TLS1v2 : NRF_SPROTO_DTLS1v2;
+	int proto = sock->type == SOCK_STREAM ? IPPROTO_TLS_1_2 : IPPROTO_DTLS_1_2;
 
-	if (sock->family != NRF_AF_INET && sock->family != NRF_AF_INET6) {
+	if (sock->family != AF_INET && sock->family != AF_INET6) {
 		LOG_ERR("Socket family %d not supported", sock->family);
 		return -ENOTSUP;
 	}
 
-	if (sock->type != NRF_SOCK_STREAM && sock->type != NRF_SOCK_DGRAM) {
+	if (sock->type != SOCK_STREAM && sock->type != SOCK_DGRAM) {
 		LOG_ERR("Socket type %d not supported", sock->type);
 		return -ENOTSUP;
 	}
 
-	ret = nrf_socket(sock->family, sock->type, proto);
+	ret = zsock_socket(sock->family, sock->type, proto);
 	if (ret < 0) {
-		LOG_ERR("nrf_socket() error: %d", -errno);
+		LOG_ERR("zsock_socket() error: %d", -errno);
 		return -errno;
 	}
 	sock->fd = ret;
 
 	struct timeval tmo = {.tv_sec = SOCKET_SEND_TMO_SEC};
 
-	ret = nrf_setsockopt(sock->fd, NRF_SOL_SOCKET, NRF_SO_SNDTIMEO, &tmo, sizeof(tmo));
+	ret = zsock_setsockopt(sock->fd, SOL_SOCKET, SO_SNDTIMEO, &tmo, sizeof(tmo));
 	if (ret) {
-		LOG_ERR("nrf_setsockopt(%d) error: %d", NRF_SO_SNDTIMEO, -errno);
+		LOG_ERR("zsock_setsockopt(%d) error: %d", SO_SNDTIMEO, -errno);
 		ret = -errno;
 		goto error;
 	}
@@ -653,19 +654,19 @@ static int do_secure_socket_open(struct sm_socket *sock, int peer_verify)
 	}
 	sec_tag_t sec_tag_list[1] = { sock->sec_tag };
 
-	ret = nrf_setsockopt(sock->fd, NRF_SOL_SECURE, NRF_SO_SEC_TAG_LIST, sec_tag_list,
+	ret = zsock_setsockopt(sock->fd, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag_list,
 			       sizeof(sec_tag_t));
 	if (ret) {
-		LOG_ERR("nrf_setsockopt(%d) error: %d", NRF_SO_SEC_TAG_LIST, -errno);
+		LOG_ERR("zsock_setsockopt(%d) error: %d", TLS_SEC_TAG_LIST, -errno);
 		ret = -errno;
 		goto error;
 	}
 
 	/* Set up (D)TLS peer verification */
-	ret = nrf_setsockopt(sock->fd, NRF_SOL_SECURE, NRF_SO_SEC_PEER_VERIFY, &peer_verify,
+	ret = zsock_setsockopt(sock->fd, SOL_TLS, TLS_PEER_VERIFY, &peer_verify,
 			       sizeof(peer_verify));
 	if (ret) {
-		LOG_ERR("nrf_setsockopt(%d) error: %d", NRF_SO_SEC_PEER_VERIFY, -errno);
+		LOG_ERR("zsock_setsockopt(%d) error: %d", TLS_PEER_VERIFY, -errno);
 		ret = -errno;
 		goto error;
 	}
@@ -683,12 +684,13 @@ static int do_secure_socket_open(struct sm_socket *sock, int peer_verify)
 	sock->async_poll.adr_hex = poll_ctx->adr_hex;
 	sock->async_poll.xapoll_events_requested = poll_ctx->xapoll_events_requested;
 	update_poll_events(
-		sock, NRF_POLLIN | NRF_POLLOUT | NRF_POLLERR | NRF_POLLHUP | NRF_POLLNVAL, true);
+		sock, ZSOCK_POLLIN | ZSOCK_POLLOUT | ZSOCK_POLLERR | ZSOCK_POLLHUP | ZSOCK_POLLNVAL,
+		true);
 
 	return 0;
 
 error:
-	nrf_close(sock->fd);
+	zsock_close(sock->fd);
 	sock->fd = INVALID_SOCKET;
 	return ret;
 }
@@ -701,9 +703,9 @@ static int do_socket_close(struct sm_socket *sock)
 		return 0;
 	}
 
-	ret = nrf_close(sock->fd);
+	ret = zsock_close(sock->fd);
 	if (ret) {
-		LOG_WRN("nrf_close() error: %d", -errno);
+		LOG_WRN("zsock_close() error: %d", -errno);
 		ret = -errno;
 	}
 
@@ -718,44 +720,44 @@ static int at_sockopt_to_sockopt(enum at_sockopt at_option, int *level, int *opt
 {
 	switch (at_option) {
 	case AT_SO_REUSEADDR:
-		*level = NRF_SOL_SOCKET;
-		*option = NRF_SO_REUSEADDR;
+		*level = SOL_SOCKET;
+		*option = SO_REUSEADDR;
 		break;
 	case AT_SO_RCVTIMEO:
-		*level = NRF_SOL_SOCKET;
-		*option = NRF_SO_RCVTIMEO;
+		*level = SOL_SOCKET;
+		*option = SO_RCVTIMEO;
 		break;
 	case AT_SO_SNDTIMEO:
-		*level = NRF_SOL_SOCKET;
-		*option = NRF_SO_SNDTIMEO;
+		*level = SOL_SOCKET;
+		*option = SO_SNDTIMEO;
 		break;
 	case AT_SO_SILENCE_ALL:
-		*level = NRF_IPPROTO_ALL;
-		*option = NRF_SO_SILENCE_ALL;
+		*level = IPPROTO_ALL;
+		*option = SO_SILENCE_ALL;
 		break;
 	case AT_SO_IP_ECHO_REPLY:
-		*level = NRF_IPPROTO_IP;
-		*option = NRF_SO_IP_ECHO_REPLY;
+		*level = IPPROTO_IP;
+		*option = SO_IP_ECHO_REPLY;
 		break;
 	case AT_SO_IPV6_ECHO_REPLY:
-		*level = NRF_IPPROTO_IPV6;
-		*option = NRF_SO_IPV6_ECHO_REPLY;
+		*level = IPPROTO_IPV6;
+		*option = SO_IPV6_ECHO_REPLY;
 		break;
 	case AT_SO_IPV6_DELAYED_ADDR_REFRESH:
-		*level = NRF_IPPROTO_IPV6;
-		*option = NRF_SO_IPV6_DELAYED_ADDR_REFRESH;
+		*level = IPPROTO_IPV6;
+		*option = SO_IPV6_DELAYED_ADDR_REFRESH;
 		break;
 	case AT_SO_BINDTOPDN:
-		*level = NRF_SOL_SOCKET;
-		*option = NRF_SO_BINDTOPDN;
+		*level = SOL_SOCKET;
+		*option = SO_BINDTOPDN;
 		break;
 	case AT_SO_RAI:
-		*level = NRF_SOL_SOCKET;
-		*option = NRF_SO_RAI;
+		*level = SOL_SOCKET;
+		*option = SO_RAI;
 		break;
 	case AT_SO_TCP_SRV_SESSTIMEO:
-		*level = NRF_IPPROTO_TCP;
-		*option = NRF_SO_TCP_SRV_SESSTIMEO;
+		*level = IPPROTO_TCP;
+		*option = SO_TCP_SRV_SESSTIMEO;
 		break;
 
 	default:
@@ -779,15 +781,15 @@ static int sockopt_set(struct sm_socket *sock, enum at_sockopt at_option, int at
 	}
 
 	/* Options with special handling. */
-	if (level == NRF_SOL_SOCKET && (option == NRF_SO_RCVTIMEO || option == NRF_SO_SNDTIMEO)) {
+	if (level == SOL_SOCKET && (option == SO_RCVTIMEO || option == SO_SNDTIMEO)) {
 		tmo.tv_sec = at_value;
 		value = &tmo;
 		len = sizeof(tmo);
 	}
 
-	ret = nrf_setsockopt(sock->fd, level, option, value, len);
+	ret = zsock_setsockopt(sock->fd, level, option, value, len);
 	if (ret) {
-		LOG_ERR("nrf_setsockopt(%d,%d,%d) error: %d", sock->fd, level, option, -errno);
+		LOG_ERR("zsock_setsockopt(%d,%d,%d) error: %d", sock->fd, level, option, -errno);
 	}
 
 	return ret;
@@ -804,24 +806,24 @@ static int sockopt_get(struct sm_socket *sock, enum at_sockopt at_option)
 	}
 
 	/* Options with special handling. */
-	if (level == NRF_SOL_SOCKET && (option == NRF_SO_RCVTIMEO || option == NRF_SO_SNDTIMEO)) {
+	if (level == SOL_SOCKET && (option == SO_RCVTIMEO || option == SO_SNDTIMEO)) {
 		struct timeval tmo;
 
 		len = sizeof(struct timeval);
-		ret = nrf_getsockopt(sock->fd, level, option, &tmo, &len);
+		ret = zsock_getsockopt(sock->fd, level, option, &tmo, &len);
 		if (ret == 0) {
 			rsp_send("\r\n#XSOCKETOPT: %d,%ld\r\n", sock->fd, (long)tmo.tv_sec);
 		}
 	} else {
 		/* Default */
-		ret = nrf_getsockopt(sock->fd, level, option, &value, &len);
+		ret = zsock_getsockopt(sock->fd, level, option, &value, &len);
 		if (ret == 0) {
 			rsp_send("\r\n#XSOCKETOPT: %d,%d\r\n", sock->fd, value);
 		}
 	}
 
 	if (ret) {
-		LOG_ERR("nrf_getsockopt(%d,%d,%d) error: %d", sock->fd, level, option, -errno);
+		LOG_ERR("zsock_getsockopt(%d,%d,%d) error: %d", sock->fd, level, option, -errno);
 	}
 
 	return ret;
@@ -829,35 +831,35 @@ static int sockopt_get(struct sm_socket *sock, enum at_sockopt at_option)
 
 static int at_sec_sockopt_to_sockopt(enum at_sec_sockopt at_option, int *level, int *option)
 {
-	*level = NRF_SOL_SECURE;
+	*level = SOL_TLS;
 
 	switch (at_option) {
 	case AT_TLS_HOSTNAME:
-		*option = NRF_SO_SEC_HOSTNAME;
+		*option = TLS_HOSTNAME;
 		break;
 	case AT_TLS_CIPHERSUITE_USED:
-		*option = NRF_SO_SEC_CIPHERSUITE_USED;
+		*option = TLS_CIPHERSUITE_USED;
 		break;
 	case AT_TLS_PEER_VERIFY:
-		*option = NRF_SO_SEC_PEER_VERIFY;
+		*option = TLS_PEER_VERIFY;
 		break;
 	case AT_TLS_SESSION_CACHE:
-		*option = NRF_SO_SEC_SESSION_CACHE;
+		*option = TLS_SESSION_CACHE;
 		break;
 	case AT_TLS_SESSION_CACHE_PURGE:
-		*option = NRF_SO_SEC_SESSION_CACHE_PURGE;
+		*option = TLS_SESSION_CACHE_PURGE;
 		break;
 	case AT_TLS_DTLS_CID:
-		*option = NRF_SO_SEC_DTLS_CID;
+		*option = TLS_DTLS_CID;
 		break;
 	case AT_TLS_DTLS_CID_STATUS:
-		*option = NRF_SO_SEC_DTLS_CID_STATUS;
+		*option = TLS_DTLS_CID_STATUS;
 		break;
 	case AT_TLS_DTLS_HANDSHAKE_TIMEO:
-		*option = NRF_SO_SEC_DTLS_HANDSHAKE_TIMEO;
+		*option = TLS_DTLS_HANDSHAKE_TIMEO;
 		break;
 	case AT_TLS_DTLS_FRAG_EXT:
-		*option = NRF_SO_SEC_DTLS_FRAG_EXT;
+		*option = TLS_DTLS_FRAG_EXT;
 		break;
 	default:
 		LOG_WRN("Unsupported option: %d", at_option);
@@ -878,7 +880,7 @@ static int sec_sockopt_set(struct sm_socket *sock, enum at_sec_sockopt at_option
 	}
 
 	/* Options with special handling. */
-	if (level == ZSOCK_SOL_TLS && option == ZSOCK_TLS_HOSTNAME) {
+	if (level == SOL_TLS && option == TLS_HOSTNAME) {
 		if (sm_util_casecmp(value, "NULL")) {
 			value = NULL;
 			len = 0;
@@ -887,9 +889,9 @@ static int sec_sockopt_set(struct sm_socket *sock, enum at_sec_sockopt at_option
 		return -EINVAL;
 	}
 
-	ret = nrf_setsockopt(sock->fd, level, option, value, len);
+	ret = zsock_setsockopt(sock->fd, level, option, value, len);
 	if (ret) {
-		LOG_ERR("nrf_setsockopt(%d,%d,%d) error: %d", sock->fd, level, option, -errno);
+		LOG_ERR("zsock_setsockopt(%d,%d,%d) error: %d", sock->fd, level, option, -errno);
 	}
 
 	return ret;
@@ -906,29 +908,29 @@ static int sec_sockopt_get(struct sm_socket *sock, enum at_sec_sockopt at_option
 	}
 
 	/* Options with special handling. */
-	if (level == NRF_SOL_SECURE && option == NRF_SO_SEC_CIPHERSUITE_USED) {
-		ret = nrf_getsockopt(sock->fd, level, option, &value, &len);
+	if (level == SOL_TLS && option == TLS_CIPHERSUITE_USED) {
+		ret = zsock_getsockopt(sock->fd, level, option, &value, &len);
 		if (ret == 0) {
 			rsp_send("\r\n#XSSOCKETOPT: %d,0x%x\r\n", sock->fd, value);
 		}
-	} else if (level == NRF_SOL_SECURE && option == NRF_SO_SEC_HOSTNAME) {
+	} else if (level == SOL_TLS && option == TLS_HOSTNAME) {
 		char hostname[SM_MAX_URL] = {0};
 
 		len = sizeof(hostname);
-		ret = nrf_getsockopt(sock->fd, level, option, &hostname, &len);
+		ret = zsock_getsockopt(sock->fd, level, option, &hostname, &len);
 		if (ret == 0) {
 			rsp_send("\r\n#XSSOCKETOPT: %d,%s\r\n", sock->fd, hostname);
 		}
 	} else {
 		/* Default */
-		ret = nrf_getsockopt(sock->fd, level, option, &value, &len);
+		ret = zsock_getsockopt(sock->fd, level, option, &value, &len);
 		if (ret == 0) {
 			rsp_send("\r\n#XSSOCKETOPT: %d,%d\r\n", sock->fd, value);
 		}
 	}
 
 	if (ret) {
-		LOG_ERR("nrf_getsockopt(%d,%d,%d) error: %d", sock->fd, level, option, -errno);
+		LOG_ERR("zsock_getsockopt(%d,%d,%d) error: %d", sock->fd, level, option, -errno);
 	}
 
 	return ret;
@@ -938,8 +940,8 @@ static int bind_to_local_addr(struct sm_socket *sock, uint16_t port)
 {
 	int ret;
 
-	if (sock->family == NRF_AF_INET) {
-		char ipv4_addr[NRF_INET_ADDRSTRLEN];
+	if (sock->family == AF_INET) {
+		char ipv4_addr[INET_ADDRSTRLEN];
 
 		util_get_ip_addr(sock->cid, ipv4_addr, NULL);
 		if (!*ipv4_addr) {
@@ -947,25 +949,25 @@ static int bind_to_local_addr(struct sm_socket *sock, uint16_t port)
 			return -ENETDOWN;
 		}
 
-		struct nrf_sockaddr_in local = {
-			.sin_family = NRF_AF_INET,
+		struct sockaddr_in local = {
+			.sin_family = AF_INET,
 			.sin_port = net_htons(port)
 		};
 
-		if (nrf_inet_pton(NRF_AF_INET, ipv4_addr, &local.sin_addr) != 1) {
+		if (zsock_inet_pton(AF_INET, ipv4_addr, &local.sin_addr) != 1) {
 			LOG_ERR("Parse local IPv4 address failed: %d", -errno);
 			return -EINVAL;
 		}
 
-		ret = nrf_bind(sock->fd, (struct nrf_sockaddr *)&local,
-			       sizeof(struct nrf_sockaddr_in));
+		ret = zsock_bind(sock->fd, (struct sockaddr *)&local,
+			       sizeof(struct sockaddr_in));
 		if (ret) {
-			LOG_ERR("nrf_bind() sock %d failed: %d", sock->fd, -errno);
+			LOG_ERR("zsock_bind() sock %d failed: %d", sock->fd, -errno);
 			return -errno;
 		}
 		LOG_DBG("bind sock %d to %s", sock->fd, ipv4_addr);
-	} else if (sock->family == NRF_AF_INET6) {
-		char ipv6_addr[NRF_INET6_ADDRSTRLEN];
+	} else if (sock->family == AF_INET6) {
+		char ipv6_addr[INET6_ADDRSTRLEN];
 
 		util_get_ip_addr(sock->cid, NULL, ipv6_addr);
 		if (!*ipv6_addr) {
@@ -973,19 +975,19 @@ static int bind_to_local_addr(struct sm_socket *sock, uint16_t port)
 			return -ENETDOWN;
 		}
 
-		struct nrf_sockaddr_in6 local = {
-			.sin6_family = NRF_AF_INET6,
+		struct sockaddr_in6 local = {
+			.sin6_family = AF_INET6,
 			.sin6_port = net_htons(port)
 		};
 
-		if (nrf_inet_pton(NRF_AF_INET6, ipv6_addr, &local.sin6_addr) != 1) {
+		if (zsock_inet_pton(AF_INET6, ipv6_addr, &local.sin6_addr) != 1) {
 			LOG_ERR("Parse local IPv6 address failed: %d", -errno);
 			return -EINVAL;
 		}
-		ret = nrf_bind(sock->fd, (struct nrf_sockaddr *)&local,
-			       sizeof(struct nrf_sockaddr_in6));
+		ret = zsock_bind(sock->fd, (struct sockaddr *)&local,
+			       sizeof(struct sockaddr_in6));
 		if (ret) {
-			LOG_ERR("nrf_bind() sock %d failed: %d", sock->fd, -errno);
+			LOG_ERR("zsock_bind() sock %d failed: %d", sock->fd, -errno);
 			return -errno;
 		}
 		LOG_DBG("bind sock %d to %s", sock->fd, ipv6_addr);
@@ -1007,15 +1009,15 @@ static int do_connect(struct sm_socket *sock, const char *url, uint16_t port)
 	if (ret) {
 		return -EAGAIN;
 	}
-	if (sa.sa_family == NRF_AF_INET) {
-		ret = nrf_connect(sock->fd, (struct nrf_sockaddr *)&sa,
-				  sizeof(struct nrf_sockaddr_in));
+	if (sa.sa_family == AF_INET) {
+		ret = zsock_connect(sock->fd, (struct sockaddr *)&sa,
+				  sizeof(struct sockaddr_in));
 	} else {
-		ret = nrf_connect(sock->fd, (struct nrf_sockaddr *)&sa,
-				  sizeof(struct nrf_sockaddr_in6));
+		ret = zsock_connect(sock->fd, (struct sockaddr *)&sa,
+				  sizeof(struct sockaddr_in6));
 	}
 	if (ret) {
-		LOG_ERR("nrf_connect() error: %d", -errno);
+		LOG_ERR("zsock_connect() error: %d", -errno);
 		return -errno;
 	}
 
@@ -1051,7 +1053,7 @@ static int do_send(struct sm_socket *sock, const uint8_t *data, int len, int fla
 	uint32_t sent = 0;
 
 	while (sent < len) {
-		ret = nrf_send(sockfd, data + sent, len - sent, flags);
+		ret = zsock_send(sockfd, data + sent, len - sent, flags);
 		if (ret < 0) {
 			LOG_ERR("Sent %u out of %u bytes. (%d)", sent, len, -errno);
 			ret = -errno;
@@ -1067,7 +1069,7 @@ static int do_send(struct sm_socket *sock, const uint8_t *data, int len, int fla
 			 sent);
 	}
 	if (!send_ntf) {
-		update_poll_events(sock, NRF_POLLOUT, true);
+		update_poll_events(sock, ZSOCK_POLLOUT, true);
 	}
 
 	return sent > 0 ? sent : ret;
@@ -1104,14 +1106,14 @@ static int do_recv(struct sm_socket *sock, int timeout, int flags,
 	int sockfd = sock->fd;
 	struct timeval tmo = {.tv_sec = timeout};
 
-	ret = nrf_setsockopt(sock->fd, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO, &tmo, sizeof(tmo));
+	ret = zsock_setsockopt(sock->fd, SOL_SOCKET, SO_RCVTIMEO, &tmo, sizeof(tmo));
 	if (ret) {
-		LOG_ERR("nrf_setsockopt(%d) error: %d", NRF_SO_RCVTIMEO, -errno);
+		LOG_ERR("zsock_setsockopt(%d) error: %d", SO_RCVTIMEO, -errno);
 		return -errno;
 	}
-	ret = nrf_recv(sockfd, (void *)sm_data_buf, data_len, flags);
+	ret = zsock_recv(sockfd, (void *)sm_data_buf, data_len, flags);
 	if (ret < 0) {
-		LOG_WRN("nrf_recv() error: %d", -errno);
+		LOG_WRN("zsock_recv() error: %d", -errno);
 		return -errno;
 	}
 	/**
@@ -1122,7 +1124,7 @@ static int do_recv(struct sm_socket *sock, int timeout, int flags,
 	 * In both cases, treat as normal shutdown by remote
 	 */
 	if (ret == 0) {
-		LOG_WRN("nrf_recv() return 0");
+		LOG_WRN("zsock_recv() return 0");
 	} else {
 		if (!in_datamode(sock->pipe)) {
 			rsp_send("\r\n#XRECV: %d,%d,%d\r\n", sock->fd, mode, ret);
@@ -1138,7 +1140,7 @@ static int do_recv(struct sm_socket *sock, int timeout, int flags,
 		}
 		ret = 0;
 
-		update_poll_events(sock, NRF_POLLIN, true);
+		update_poll_events(sock, ZSOCK_POLLIN, true);
 	}
 
 	return ret;
@@ -1174,19 +1176,18 @@ static int do_sendto(struct sm_socket *sock, const char *url, uint16_t port, con
 	}
 
 	do {
-		ret = nrf_sendto(sock->fd, data + sent, len - sent, flags,
-				 (struct nrf_sockaddr *)&sa,
-				 sa.sa_family == NRF_AF_INET ? sizeof(struct nrf_sockaddr_in)
-							     : sizeof(struct nrf_sockaddr_in6));
+		ret = zsock_sendto(sock->fd, data + sent, len - sent, flags, &sa,
+				   sa.sa_family == AF_INET ? sizeof(struct sockaddr_in)
+							   : sizeof(struct sockaddr_in6));
 		if (ret <= 0) {
 			ret = -errno;
 			break;
 		}
 		sent += ret;
 
-	} while (sock->type != NRF_SOCK_DGRAM && sent < len);
+	} while (sock->type != SOCK_DGRAM && sent < len);
 
-	if (ret >= 0 && sock->type == NRF_SOCK_DGRAM && sent != len) {
+	if (ret >= 0 && sock->type == SOCK_DGRAM && sent != len) {
 		/* Partial send of datagram. */
 		ret = -EAGAIN;
 		sent = 0;
@@ -1203,7 +1204,7 @@ static int do_sendto(struct sm_socket *sock, const char *url, uint16_t port, con
 			 sent);
 	}
 	if (!send_ntf) {
-		update_poll_events(sock, NRF_POLLOUT, true);
+		update_poll_events(sock, ZSOCK_POLLOUT, true);
 	}
 
 	return sent > 0 ? sent : ret;
@@ -1217,15 +1218,15 @@ static int do_recvfrom(struct sm_socket *sock, int timeout, int flags,
 	net_socklen_t addrlen = sizeof(struct net_sockaddr);
 	struct timeval tmo = {.tv_sec = timeout};
 
-	ret = nrf_setsockopt(sock->fd, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO, &tmo, sizeof(tmo));
+	ret = zsock_setsockopt(sock->fd, SOL_SOCKET, SO_RCVTIMEO, &tmo, sizeof(tmo));
 	if (ret) {
-		LOG_ERR("nrf_setsockopt(%d) error: %d", NRF_SO_RCVTIMEO, -errno);
+		LOG_ERR("zsock_setsockopt(%d) error: %d", SO_RCVTIMEO, -errno);
 		return -errno;
 	}
-	ret = nrf_recvfrom(sock->fd, (void *)sm_data_buf, data_len, flags,
-			   (struct nrf_sockaddr *)&remote, &addrlen);
+	ret = zsock_recvfrom(sock->fd, (void *)sm_data_buf, data_len, flags,
+			   (struct sockaddr *)&remote, &addrlen);
 	if (ret < 0) {
-		LOG_ERR("nrf_recvfrom() error: %d", -errno);
+		LOG_ERR("zsock_recvfrom() error: %d", -errno);
 		return -errno;
 	}
 	/**
@@ -1234,10 +1235,10 @@ static int do_recvfrom(struct sm_socket *sock, int timeout, int flags,
 	 * value is 0. Treat as normal case
 	 */
 	if (ret == 0) {
-		LOG_WRN("nrf_recvfrom() return 0");
+		LOG_WRN("zsock_recvfrom() return 0");
 	} else {
 		if (!in_datamode(sock->pipe)) {
-			char peer_addr[NRF_INET6_ADDRSTRLEN] = {0};
+			char peer_addr[INET6_ADDRSTRLEN] = {0};
 			uint16_t peer_port = 0;
 
 			util_get_peer_addr((struct net_sockaddr *)&remote, peer_addr, &peer_port);
@@ -1254,7 +1255,7 @@ static int do_recvfrom(struct sm_socket *sock, int timeout, int flags,
 			data_send(sock->pipe, sm_data_buf, ret);
 		}
 
-		update_poll_events(sock, NRF_POLLIN, true);
+		update_poll_events(sock, ZSOCK_POLLIN, true);
 	}
 
 	return 0;
@@ -1267,7 +1268,7 @@ static int socket_datamode_callback(uint8_t op, const uint8_t *data, int len, ui
 		sm_at_host_get_async_poll_ctx(sm_at_host_get_current_pipe());
 
 	if (op == DATAMODE_SEND) {
-		if (poll_ctx->datamode_sock->type == NRF_SOCK_DGRAM &&
+		if (poll_ctx->datamode_sock->type == SOCK_DGRAM &&
 		    (flags & SM_DATAMODE_FLAGS_MORE_DATA) != 0) {
 			LOG_ERR("Data mode buffer overflow");
 			exit_datamode_handler(sm_at_host_get_current(), -EOVERFLOW);
@@ -1359,8 +1360,8 @@ STATIC int handle_at_socket(enum at_parser_cmd_type cmd_type, struct at_parser *
 
 	case AT_PARSER_CMD_TYPE_TEST:
 		rsp_send("\r\n#XSOCKET: <handle>,(%d,%d,%d),(%d,%d,%d),(%d,%d),<cid>\r\n",
-			NRF_AF_INET, NRF_AF_INET6, NRF_AF_PACKET,
-			NRF_SOCK_STREAM, NRF_SOCK_DGRAM, NRF_SOCK_RAW,
+			AF_INET, AF_INET6, AF_PACKET,
+			SOCK_STREAM, SOCK_DGRAM, SOCK_RAW,
 			AT_SOCKET_ROLE_CLIENT, AT_SOCKET_ROLE_SERVER);
 		err = 0;
 		break;
@@ -1452,8 +1453,8 @@ STATIC int handle_at_secure_socket(enum at_parser_cmd_type cmd_type,
 	case AT_PARSER_CMD_TYPE_TEST:
 		rsp_send("\r\n#XSSOCKET: <handle>,(%d,%d),(%d,%d),(%d,%d),"
 			 "<sec_tag>,<peer_verify>,<cid>\r\n",
-			NRF_AF_INET, NRF_AF_INET6,
-			NRF_SOCK_STREAM, NRF_SOCK_DGRAM,
+			AF_INET, AF_INET6,
+			SOCK_STREAM, SOCK_DGRAM,
 			AT_SOCKET_ROLE_CLIENT, AT_SOCKET_ROLE_SERVER);
 		err = 0;
 		break;
@@ -1782,7 +1783,7 @@ STATIC int handle_at_send(enum at_parser_cmd_type cmd_type, struct at_parser *pa
 			poll_ctx->datamode_sock = sock;
 			err = enter_datamode(socket_datamode_callback, data_len);
 			if (!err && sock->async_poll.adr_flags & SM_ADR_DATA_MODE) {
-				update_poll_events(sock, NRF_POLLIN, false);
+				update_poll_events(sock, ZSOCK_POLLIN, false);
 			}
 		} else {
 			return -EINVAL;
@@ -1935,7 +1936,7 @@ STATIC int handle_at_sendto(enum at_parser_cmd_type cmd_type, struct at_parser *
 			poll_ctx->datamode_sock = sock;
 			err = enter_datamode(socket_datamode_callback, data_len);
 			if (!err && sock->async_poll.adr_flags & SM_ADR_DATA_MODE) {
-				update_poll_events(sock, NRF_POLLIN, false);
+				update_poll_events(sock, ZSOCK_POLLIN, false);
 			}
 		} else {
 			return -EINVAL;
@@ -2011,22 +2012,22 @@ static int do_listen(struct sm_socket *sock)
 {
 	int ret;
 
-	if (sock->type != NRF_SOCK_STREAM || sock->local_port == 0 ||
+	if (sock->type != SOCK_STREAM || sock->local_port == 0 ||
 	    sock->sec_tag != SEC_TAG_TLS_INVALID) {
 		return -EOPNOTSUPP;
 	}
 
 	/* Set the socket to non-blocking mode, so accept() won't block. */
-	ret = nrf_fcntl(sock->fd, NRF_F_SETFL, NRF_O_NONBLOCK);
+	ret = zsock_fcntl(sock->fd, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	if (ret) {
-		LOG_ERR("nrf_fcntl() failed: %d", -errno);
+		LOG_ERR("zsock_fcntl() failed: %d", -errno);
 		return -errno;
 	}
 
 	/* nRF modem ignores the backlog parameter. Backlog in modem is fixed to 2. */
-	ret = nrf_listen(sock->fd, 2);
+	ret = zsock_listen(sock->fd, 2);
 	if (ret) {
-		LOG_ERR("nrf_listen() failed: %d", -errno);
+		LOG_ERR("zsock_listen() failed: %d", -errno);
 		return -errno;
 	}
 
@@ -2083,30 +2084,30 @@ static int do_accept(struct sm_socket *sock)
 	int ret;
 	struct net_sockaddr remote;
 	net_socklen_t addrlen = sizeof(struct net_sockaddr);
-	char peer_addr[NRF_INET6_ADDRSTRLEN] = {0};
+	char peer_addr[INET6_ADDRSTRLEN] = {0};
 	uint16_t peer_port = 0;
 	struct async_poll_ctx *poll_ctx = poll_ctx_from_sock(sock);
 
-	if (sock->type != NRF_SOCK_STREAM || !sock->listen) {
+	if (sock->type != SOCK_STREAM || !sock->listen) {
 		return -EOPNOTSUPP;
 	}
 
-	ret = nrf_accept(sock->fd, (struct nrf_sockaddr *)&remote, (nrf_socklen_t *)&addrlen);
+	ret = zsock_accept(sock->fd, (struct sockaddr *)&remote, (socklen_t *)&addrlen);
 	if (ret < 0) {
-		LOG_ERR("nrf_accept() failed: %d", -errno);
+		LOG_ERR("zsock_accept() failed: %d", -errno);
 		return -errno;
 	}
 
 	struct sm_socket *new_sock = find_avail_socket();
 	if (new_sock == NULL) {
 		LOG_ERR("Max socket count reached, closing accepted socket");
-		nrf_close(ret);
+		zsock_close(ret);
 		return -EINVAL;
 	}
 	init_socket(new_sock);
 	new_sock->fd = ret;
 	new_sock->family = remote.sa_family;
-	new_sock->type = NRF_SOCK_STREAM;
+	new_sock->type = SOCK_STREAM;
 	new_sock->role = AT_SOCKET_ROLE_CLIENT;
 	new_sock->cid = sock->cid;
 	new_sock->connected = true;
@@ -2120,11 +2121,12 @@ static int do_accept(struct sm_socket *sock)
 	new_sock->async_poll.adr_hex = poll_ctx->adr_hex;
 	new_sock->async_poll.xapoll_events_requested = poll_ctx->xapoll_events_requested;
 	update_poll_events(new_sock,
-			   NRF_POLLIN | NRF_POLLOUT | NRF_POLLERR | NRF_POLLHUP | NRF_POLLNVAL,
+			   ZSOCK_POLLIN | ZSOCK_POLLOUT | ZSOCK_POLLERR | ZSOCK_POLLHUP |
+				   ZSOCK_POLLNVAL,
 			   true);
 
 	/* Restore POLLIN for listening socket. */
-	update_poll_events(sock, NRF_POLLIN, true);
+	update_poll_events(sock, ZSOCK_POLLIN, true);
 
 	return 0;
 }
@@ -2167,11 +2169,11 @@ STATIC int handle_at_getaddrinfo(enum at_parser_cmd_type cmd_type, struct at_par
 				 uint32_t param_count)
 {
 	int err = -EINVAL;
-	char hostname[ZSOCK_NI_MAXHOST];
+	char hostname[NI_MAXHOST];
 	char host[SM_MAX_URL];
 	int size = SM_MAX_URL;
-	struct nrf_addrinfo *result;
-	struct nrf_addrinfo *res;
+	struct zsock_addrinfo *result;
+	struct zsock_addrinfo *res;
 	char rsp_buf[256];
 
 	switch (cmd_type) {
@@ -2182,19 +2184,19 @@ STATIC int handle_at_getaddrinfo(enum at_parser_cmd_type cmd_type, struct at_par
 		}
 		if (param_count == 3) {
 			/* DNS query with designated address family */
-			struct nrf_addrinfo hints = {
-				.ai_family = NRF_AF_UNSPEC
+			struct zsock_addrinfo hints = {
+				.ai_family = AF_UNSPEC
 			};
 			err = at_parser_num_get(parser, 2, &hints.ai_family);
 			if (err) {
 				return err;
 			}
-			if (hints.ai_family < 0  || hints.ai_family > NRF_AF_INET6) {
+			if (hints.ai_family < 0  || hints.ai_family > AF_INET6) {
 				return -EINVAL;
 			}
-			err = nrf_getaddrinfo(host, NULL, &hints, &result);
+			err = zsock_getaddrinfo(host, NULL, &hints, &result);
 		} else if (param_count == 2) {
-			err = nrf_getaddrinfo(host, NULL, NULL, &result);
+			err = zsock_getaddrinfo(host, NULL, NULL, &result);
 		} else {
 			return -EINVAL;
 		}
@@ -2209,17 +2211,17 @@ STATIC int handle_at_getaddrinfo(enum at_parser_cmd_type cmd_type, struct at_par
 		sprintf(rsp_buf, "\r\n#XGETADDRINFO: \"");
 		/* loop over all returned results and do inverse lookup */
 		for (res = result; res != NULL; res = res->ai_next) {
-			if (res->ai_family == NRF_AF_INET) {
-				struct nrf_sockaddr_in *host =
-					(struct nrf_sockaddr_in *)result->ai_addr;
+			if (res->ai_family == AF_INET) {
+				struct sockaddr_in *host =
+					(struct sockaddr_in *)res->ai_addr;
 
-				nrf_inet_ntop(NRF_AF_INET, &host->sin_addr, hostname,
+				zsock_inet_ntop(AF_INET, &host->sin_addr, hostname,
 					      sizeof(hostname));
-			} else if (res->ai_family == NRF_AF_INET6) {
-				struct nrf_sockaddr_in6 *host =
-					(struct nrf_sockaddr_in6 *)result->ai_addr;
+			} else if (res->ai_family == AF_INET6) {
+				struct sockaddr_in6 *host =
+					(struct sockaddr_in6 *)res->ai_addr;
 
-				nrf_inet_ntop(NRF_AF_INET6, &host->sin6_addr, hostname,
+				zsock_inet_ntop(AF_INET6, &host->sin6_addr, hostname,
 					      sizeof(hostname));
 			} else {
 				continue;
@@ -2232,7 +2234,7 @@ STATIC int handle_at_getaddrinfo(enum at_parser_cmd_type cmd_type, struct at_par
 		}
 		strcat(rsp_buf, "\"\r\n");
 		rsp_send("%s", rsp_buf);
-		nrf_freeaddrinfo(result);
+		zsock_freeaddrinfo(result);
 		break;
 
 	default:
@@ -2273,7 +2275,7 @@ static void xapoll_read_response(void)
 		    socks[i].pipe == pipe) {
 			rsp_send("\r\n#XAPOLL: %d,%d\r\n", socks[i].fd,
 				 socks[i].async_poll.xapoll_events_requested &
-					 ~(NRF_POLLERR | NRF_POLLHUP | NRF_POLLNVAL));
+					 ~(ZSOCK_POLLERR | ZSOCK_POLLHUP | ZSOCK_POLLNVAL));
 		}
 	}
 }
@@ -2349,12 +2351,12 @@ STATIC int handle_at_xapoll(enum at_parser_cmd_type cmd_type, struct at_parser *
 		if (err) {
 			return err;
 		}
-		if (events & ~(NRF_POLLIN | NRF_POLLOUT)) {
+		if (events & ~(ZSOCK_POLLIN | ZSOCK_POLLOUT)) {
 			LOG_ERR("Invalid poll events: %d", events);
 			return -EINVAL;
 		}
 		/* Libmodem always returns these. */
-		events |= NRF_POLLERR | NRF_POLLHUP | NRF_POLLNVAL;
+		events |= ZSOCK_POLLERR | ZSOCK_POLLHUP | ZSOCK_POLLNVAL;
 
 		err = set_xapoll_events(sock, events);
 		break;
@@ -2421,7 +2423,7 @@ STATIC int handle_at_recvcfg(enum at_parser_cmd_type cmd_type, struct at_parser 
 			sock->pipe = pipe;
 			sock->async_poll.adr_flags = flags;
 			sock->async_poll.adr_hex = hex_mode != 0;
-			err = update_poll_events(sock, NRF_POLLIN, false);
+			err = update_poll_events(sock, ZSOCK_POLLIN, false);
 		} else {
 			/* Apply to all sockets in this context */
 			poll_ctx->adr_flags = flags;
@@ -2430,7 +2432,7 @@ STATIC int handle_at_recvcfg(enum at_parser_cmd_type cmd_type, struct at_parser 
 				if (socks[i].fd != INVALID_SOCKET && socks[i].pipe == pipe) {
 					socks[i].async_poll.adr_flags = poll_ctx->adr_flags;
 					socks[i].async_poll.adr_hex = poll_ctx->adr_hex;
-					err = update_poll_events(&socks[i], NRF_POLLIN, false);
+					err = update_poll_events(&socks[i], ZSOCK_POLLIN, false);
 					if (err) {
 						return err;
 					}

--- a/app/src/sm_defines.h
+++ b/app/src/sm_defines.h
@@ -7,7 +7,6 @@
 #ifndef SM_DEFINES_
 #define SM_DEFINES_
 
-#include <nrf_socket.h>
 #include "sm_trap_macros.h"
 
 #define INVALID_SOCKET       -1
@@ -24,7 +23,7 @@ enum {
 #define SM_AT_MAX_RSP_LEN   2100
 
 /** The maximum allowed length of data send/receive through the Serial Modem */
-#define SM_MAX_MESSAGE_SIZE NRF_SOCKET_TLS_MAX_MESSAGE_SIZE
+#define SM_MAX_MESSAGE_SIZE 2048
 
 #define SM_MAX_URL          128  /** max size of URL string */
 #define SM_MAX_USERNAME     32   /** max size of username in login */

--- a/app/src/sm_ppp.c
+++ b/app/src/sm_ppp.c
@@ -302,14 +302,14 @@ static void ppp_retrieve_pdn_info(struct ppp_context *const ctx)
 #if defined(CONFIG_LTE_LC_DNS_FALLBACK_ADDRESS)
 		} else {
 			/* Use fallback DNS addresses from LTE_LC module */
-			(void)nrf_inet_pton(NRF_AF_INET, CONFIG_LTE_LC_DNS_FALLBACK_ADDRESS,
+			(void)zsock_inet_pton(AF_INET, CONFIG_LTE_LC_DNS_FALLBACK_ADDRESS,
 					    &ctx->ipcp.peer_options.dns1_address);
 			ctx->ipcp.my_options.dns1_address = ctx->ipcp.peer_options.dns1_address;
 		}
 #elif defined(CONFIG_DNS_SERVER1)
 		} else {
 			/* Use fallback DNS addresses from Zephyr */
-			(void)nrf_inet_pton(NRF_AF_INET, CONFIG_DNS_SERVER1,
+			(void)zsock_inet_pton(AF_INET, CONFIG_DNS_SERVER1,
 					    &ctx->ipcp.peer_options.dns1_address);
 			ctx->ipcp.my_options.dns1_address = ctx->ipcp.peer_options.dns1_address;
 		}

--- a/app/tests/at_socket/CMakeLists.txt
+++ b/app/tests/at_socket/CMakeLists.txt
@@ -42,6 +42,8 @@ target_compile_options(app PRIVATE
   -DCONFIG_SM_UART_TX_BUF_SIZE=256
   # Suppress upstream Zephyr warnings in net_if.h (returns address of local var)
   -Wno-return-local-addr
+  # Enable POSIX-compat socket name aliases (AF_INET, SOL_SOCKET, sockaddr, etc.)
+  -DCONFIG_NET_NAMESPACE_COMPAT_MODE=1
 )
 
 # Generate CMock mocks for external dependencies

--- a/app/tests/at_socket/src/test_at_socket.c
+++ b/app/tests/at_socket/src/test_at_socket.c
@@ -11,14 +11,15 @@
 #include <string.h>
 #include <stdarg.h>
 
-#include "nrf_socket.h"
 #include "sm_at_host.h"
 #include "uart_stub.h"
 
 /* CMock-generated mocks */
-#include "cmock_nrf_socket.h"
 #include "cmock_nrf_modem_at.h"
+#include "cmock_nrf_socket.h"
 #include "zephyr/net/cmock_socket.h"
+
+#include <zephyr/posix/fcntl.h>
 
 /* Minimal DNS error codes for tests */
 #ifndef DNS_EAI_NONAME
@@ -33,7 +34,7 @@ extern const char *get_captured_response(void);
 extern size_t get_captured_response_len(void);
 extern void clear_captured_response(void);
 
-/* Helper callbacks for mocking nrf_getsockopt with output parameters */
+/* Helper callbacks for mocking zsock_getsockopt with output parameters */
 static int mock_getsockopt_timeval_callback(int socket, int level, int option_name,
 					    void *option_value, net_socklen_t *option_len,
 					    int num_calls)
@@ -100,18 +101,18 @@ static char *mock_zsock_inet_ntop_192_168_0_100_callback(
 	return dst;
 }
 
-static int mock_nrf_accept_with_peer_callback(int socket, struct nrf_sockaddr *restrict address,
-					      nrf_socklen_t *restrict address_len, int num_calls)
+static int mock_zsock_accept_with_peer_callback(int sock, struct net_sockaddr *addr,
+					      net_socklen_t *addrlen, int cmock_num_calls)
 {
 	/* Populate the address structure with peer information */
-	struct nrf_sockaddr_in *addr_in = (struct nrf_sockaddr_in *)address;
+	struct net_sockaddr_in *addr_in = (struct net_sockaddr_in *)addr;
 
-	addr_in->sin_family = NRF_AF_INET;
-	addr_in->sin_port = nrf_htons(5555); /* Port 5555 in network byte order */
-	addr_in->sin_addr.s_addr = nrf_htonl(0xC0A80064); /* 192.168.0.100 */
+	addr_in->sin_family = AF_INET;
+	addr_in->sin_port = htons(5555); /* Port 5555 in network byte order */
+	addr_in->sin_addr.s_addr = htonl(0xC0A80064); /* 192.168.0.100 */
 
-	if (address_len) {
-		*address_len = sizeof(struct nrf_sockaddr_in);
+	if (addrlen) {
+		*addrlen = sizeof(struct sockaddr_in);
 	}
 
 	return 7; /* Return new socket fd */
@@ -127,9 +128,9 @@ void tearDown(void)
 {
 	/* This is run after EACH test */
 	/* Reset any stubs to prevent interference between tests */
-	__cmock_nrf_getsockopt_Stub(NULL);
+	__cmock_zsock_getsockopt_Stub(NULL);
 	__cmock_zsock_inet_ntop_Stub(NULL);
-	__cmock_nrf_accept_Stub(NULL);
+	__cmock_zsock_accept_Stub(NULL);
 }
 
 /*
@@ -142,9 +143,9 @@ void test_xsocket_read_operation(void)
 	const char *response;
 
 	/* Create first socket: IPv4 TCP client (fd=1) */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 1,1,6") != NULL);
@@ -152,9 +153,9 @@ void test_xsocket_read_operation(void)
 
 	clear_captured_response();
 	/* Create second socket: IPv6 UDP client (fd=2) */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=2,2,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 2,2,17") != NULL);
@@ -162,9 +163,9 @@ void test_xsocket_read_operation(void)
 
 	clear_captured_response();
 	/* Create third socket: IPv4 TCP server (fd=3) */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,1,1\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 3,1,6") != NULL);
@@ -185,11 +186,11 @@ void test_xsocket_read_operation(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close all sockets */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -242,12 +243,12 @@ void test_xsocket_ipv4_tcp(void)
 
 	/* Initialize AT host and socket subsystem */
 
-	/* Mock nrf_socket to return fd 1 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
+	/* Mock zsock_socket to return fd 1 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
 
 	/* Mock setsockopt calls (send timeout, poll callback) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 
 	/* Send AT command via sm_at_receive() */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
@@ -260,7 +261,7 @@ void test_xsocket_ipv4_tcp(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -273,12 +274,12 @@ void test_xsocket_ipv4_udp(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 1 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 1);
+	/* Mock zsock_socket to return fd 1 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 1);
 
 	/* Mock setsockopt calls (send timeout, poll callback) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 
 	/* Send AT command via sm_at_receive() */
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
@@ -291,7 +292,7 @@ void test_xsocket_ipv4_udp(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -304,12 +305,12 @@ void test_xsocket_ipv6_tcp(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 1 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
+	/* Mock zsock_socket to return fd 1 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET6, SOCK_STREAM, IPPROTO_TCP, 1);
 
 	/* Mock setsockopt calls (send timeout, poll callback) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 
 	/* Send AT command via sm_at_receive() */
 	send_at_command("AT#XSOCKET=2,1,0\r\n");
@@ -321,7 +322,7 @@ void test_xsocket_ipv6_tcp(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -334,12 +335,12 @@ void test_xsocket_raw(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 0 for RAW socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_SOCK_RAW, NRF_SOCK_RAW, NRF_IPPROTO_RAW, 0);
+	/* Mock zsock_socket to return fd 0 for RAW socket */
+	__cmock_zsock_socket_ExpectAndReturn(SOCK_RAW, SOCK_RAW, IPPROTO_RAW, 0);
 
 	/* Mock setsockopt calls (send timeout, poll callback) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 
 	/* Send AT command: family=1(IPv4), type=3(RAW), role=0(client) */
 	send_at_command("AT#XSOCKET=3,3,0\r\n");
@@ -352,7 +353,7 @@ void test_xsocket_raw(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -428,13 +429,13 @@ void test_xsocket_max_sockets(void)
 	/* Create 3 sockets (determined by NRF_MODEM_MAX_SOCKET_COUNT) */
 	for (int i = 0; i < max_sockets; i++) {
 
-		/* Mock nrf_socket to return fd */
-		__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP,
+		/* Mock zsock_socket to return fd */
+		__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP,
 						   i);
 
 		/* Mock setsockopt calls (send timeout, poll callback) */
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 
 		/* Send AT command via sm_at_receive() */
 		send_at_command("AT#XSOCKET=1,1,0\r\n");
@@ -458,7 +459,7 @@ void test_xsocket_max_sockets(void)
 	/* Clean up: close all 3 sockets */
 	for (int i = 0; i < max_sockets; i++) {
 		char send_buf[20];
-		__cmock_nrf_close_ExpectAndReturn(i, 0);
+		__cmock_zsock_close_ExpectAndReturn(i, 0);
 		sprintf(send_buf, "AT#XCLOSE=%d\r\n", i);
 		send_at_command(send_buf);
 	}
@@ -473,11 +474,11 @@ void test_xsocket_with_pdn_cid(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 4 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 4);
+	/* Mock zsock_socket to return fd 4 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 4);
 
 	/* Mock setsockopt calls */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
 
 	/* Mock AT%XGETPDNID command for PDN ID retrieval (cid=1 -> pdn_id=1) */
 	const char *pdn_id_resp = "%XGETPDNID: 1\r\nOK\r\n";
@@ -488,8 +489,8 @@ void test_xsocket_with_pdn_cid(void)
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_len(__LINE__);
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_fmt(__LINE__);
 
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_BINDTOPDN */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll callback */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_BINDTOPDN */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll callback */
 
 	/* Send AT command: family=1(IPv4), type=1(STREAM), role=0(client), cid=1 */
 	send_at_command("AT#XSOCKET=1,1,0,1\r\n");
@@ -502,7 +503,7 @@ void test_xsocket_with_pdn_cid(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -518,9 +519,9 @@ void test_xbind_operation(void)
 	const char *cgpaddr_resp = "+CGPADDR: 3,\"127.0.0.1\",\"\"\r\nOK\r\n";
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	/* Verify response contains socket handle and correct type/protocol */
 	response = get_captured_response();
@@ -530,7 +531,7 @@ void test_xbind_operation(void)
 
 	clear_captured_response();
 
-	/* Bind operation - query modem IP, inet_pton, nrf_bind */
+	/* Bind operation - query modem IP, inet_pton, zsock_bind */
 	__cmock_nrf_modem_at_cmd_CMockExpectAnyArgsAndReturn(__LINE__, 0);
 	__cmock_nrf_modem_at_cmd_CMockReturnMemThruPtr_buf(__LINE__, (void *)cgpaddr_resp,
 							   strlen(cgpaddr_resp) + 1);
@@ -538,11 +539,11 @@ void test_xbind_operation(void)
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_fmt(__LINE__);
 	/* util_get_ip_addr() validates the IP with zsock_inet_pton */
 	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
-	/* bind_to_local_addr() converts the IP with nrf_inet_pton */
-	__cmock_nrf_inet_pton_ExpectAnyArgsAndReturn(1);
-	__cmock_nrf_bind_ExpectAndReturn(0, NULL, sizeof(struct nrf_sockaddr_in), 0);
-	__cmock_nrf_bind_IgnoreArg_address();
-	__cmock_nrf_bind_IgnoreArg_address_len();
+	/* bind_to_local_addr() converts the IP with zsock_inet_pton */
+	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
+	__cmock_zsock_bind_ExpectAndReturn(0, NULL, sizeof(struct sockaddr_in), 0);
+	__cmock_zsock_bind_IgnoreArg_addr();
+	__cmock_zsock_bind_IgnoreArg_addrlen();
 
 	/* Execute bind command via sm_at_receive() */
 	send_at_command("AT#XBIND=0,8080\r\n");
@@ -552,7 +553,7 @@ void test_xbind_operation(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -568,9 +569,9 @@ void test_xbind_ipv6_operation(void)
 	const char *cgpaddr_resp = "+CGPADDR: 3,\"2001:db8::1\"\r\nOK\r\n";
 
 	/* Create IPv6 UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=2,2,0\r\n");
 	/* Verify response contains socket handle and correct type/protocol */
 	response = get_captured_response();
@@ -580,7 +581,7 @@ void test_xbind_ipv6_operation(void)
 
 	clear_captured_response();
 
-	/* Bind operation - query modem IP, inet_pton, nrf_bind */
+	/* Bind operation - query modem IP, inet_pton, zsock_bind */
 	__cmock_nrf_modem_at_cmd_CMockExpectAnyArgsAndReturn(__LINE__, 0);
 	__cmock_nrf_modem_at_cmd_CMockReturnMemThruPtr_buf(__LINE__, (void *)cgpaddr_resp,
 							   strlen(cgpaddr_resp) + 1);
@@ -588,11 +589,11 @@ void test_xbind_ipv6_operation(void)
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_fmt(__LINE__);
 	/* util_get_ip_addr() validates the IP with zsock_inet_pton */
 	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
-	/* bind_to_local_addr() converts the IP with nrf_inet_pton */
-	__cmock_nrf_inet_pton_ExpectAnyArgsAndReturn(1);
-	__cmock_nrf_bind_ExpectAndReturn(4, NULL, sizeof(struct nrf_sockaddr_in6), 0);
-	__cmock_nrf_bind_IgnoreArg_address();
-	__cmock_nrf_bind_IgnoreArg_address_len();
+	/* bind_to_local_addr() converts the IP with zsock_inet_pton */
+	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
+	__cmock_zsock_bind_ExpectAndReturn(4, NULL, sizeof(struct net_sockaddr_in6), 0);
+	__cmock_zsock_bind_IgnoreArg_addr();
+	__cmock_zsock_bind_IgnoreArg_addrlen();
 
 	/* Execute bind command via sm_at_receive() */
 	send_at_command("AT#XBIND=4,8080\r\n");
@@ -602,7 +603,7 @@ void test_xbind_ipv6_operation(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -615,9 +616,9 @@ void test_xbind_invalid_ip(void)
 
 	/* Ensure socket subsystem is initialized and handle 3 exists */
 
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
@@ -636,7 +637,7 @@ void test_xbind_invalid_ip(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Cleanup */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -647,9 +648,9 @@ void test_xbind_invalid_port(void)
 
 	/* Ensure socket subsystem is initialized and handle 3 exists */
 
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
@@ -661,7 +662,7 @@ void test_xbind_invalid_port(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Cleanup */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -672,9 +673,9 @@ void test_xconnect_invalid_ip(void)
 
 	/* Ensure socket subsystem is initialized and handle 3 exists */
 
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
@@ -692,7 +693,7 @@ void test_xconnect_invalid_ip(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Cleanup */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -703,9 +704,9 @@ void test_xconnect_invalid_port(void)
 
 	/* Ensure socket subsystem is initialized and handle 3 exists */
 
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
@@ -729,7 +730,7 @@ void test_xconnect_invalid_port(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Cleanup */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -749,14 +750,14 @@ static int mock_getaddrinfo_success_callback(const char *host, const char *servi
 
 	/* Setup a valid IPv4 address structure */
 	memset(&getaddrinfo_result, 0, sizeof(getaddrinfo_result));
-	getaddrinfo_result.addr.sa_in.sin_family = NRF_AF_INET;
+	getaddrinfo_result.addr.sa_in.sin_family = AF_INET;
 	getaddrinfo_result.addr.sa_in.sin_port = net_htons(80);
 	getaddrinfo_result.addr.sa_in.sin_addr.s_addr = net_htonl(0xC0A80001); /* 192.168.0.1 */
 
 	/* Setup addrinfo structure */
-	getaddrinfo_result.ai.ai_family = NRF_AF_INET;
-	getaddrinfo_result.ai.ai_socktype = NRF_SOCK_STREAM;
-	getaddrinfo_result.ai.ai_protocol = NRF_IPPROTO_TCP;
+	getaddrinfo_result.ai.ai_family = AF_INET;
+	getaddrinfo_result.ai.ai_socktype = SOCK_STREAM;
+	getaddrinfo_result.ai.ai_protocol = IPPROTO_TCP;
 	getaddrinfo_result.ai.ai_addrlen = sizeof(getaddrinfo_result.addr.sa_in);
 	getaddrinfo_result.ai.ai_addr = &getaddrinfo_result.addr.sa;
 
@@ -774,9 +775,9 @@ void test_xconnect_operation(void)
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
@@ -785,8 +786,8 @@ void test_xconnect_operation(void)
 	__cmock_zsock_freeaddrinfo_Expect(NULL);
 	__cmock_zsock_freeaddrinfo_IgnoreArg_ai();
 
-	/* Mock successful nrf_connect */
-	__cmock_nrf_connect_ExpectAnyArgsAndReturn(0);
+	/* Mock successful zsock_connect */
+	__cmock_zsock_connect_ExpectAnyArgsAndReturn(0);
 
 	/* Execute connect command via sm_at_receive() */
 	send_at_command("AT#XCONNECT=1,\"test.server.com\",80\r\n");
@@ -797,7 +798,7 @@ void test_xconnect_operation(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -812,9 +813,9 @@ void test_xlisten_operation(void)
 	const char *cgpaddr_resp = "+CGPADDR: 0,\"10.0.0.1\",\"\"\r\nOK\r\n";
 
 	/* Create TCP server socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 5);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 5);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,1,1\r\n"); /* family=1, type=1, role=1 (server) */
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 5,1,6") != NULL);
@@ -827,18 +828,18 @@ void test_xlisten_operation(void)
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_len(__LINE__);
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_fmt(__LINE__);
 	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
-	__cmock_nrf_inet_pton_ExpectAnyArgsAndReturn(1);
-	__cmock_nrf_bind_ExpectAndReturn(5, NULL, sizeof(struct nrf_sockaddr_in), 0);
-	__cmock_nrf_bind_IgnoreArg_address();
-	__cmock_nrf_bind_IgnoreArg_address_len();
+	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
+	__cmock_zsock_bind_ExpectAndReturn(5, NULL, sizeof(struct sockaddr_in), 0);
+	__cmock_zsock_bind_IgnoreArg_addr();
+	__cmock_zsock_bind_IgnoreArg_addrlen();
 	send_at_command("AT#XBIND=5,8080\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 	clear_captured_response();
 
 	/* Mock fcntl to set non-blocking mode and listen */
-	__cmock_nrf_fcntl_ExpectAndReturn(5, NRF_F_SETFL, NRF_O_NONBLOCK, 0);
-	__cmock_nrf_listen_ExpectAndReturn(5, 2, 0); /* backlog=2 (fixed in modem) */
+	__cmock_zsock_fcntl_wrapper_ExpectAndReturn(5, F_SETFL, 0);
+	__cmock_zsock_listen_ExpectAndReturn(5, 2, 0); /* backlog=2 (fixed in modem) */
 
 	/* Execute listen command */
 	send_at_command("AT#XLISTEN=5\r\n");
@@ -851,7 +852,7 @@ void test_xlisten_operation(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(5, 0);
+	__cmock_zsock_close_ExpectAndReturn(5, 0);
 	send_at_command("AT#XCLOSE=5\r\n");
 }
 
@@ -865,9 +866,9 @@ void test_xlisten_read_command(void)
 	const char *cgpaddr_resp = "+CGPADDR: 0,\"10.0.0.1\",\"\"\r\nOK\r\n";
 
 	/* Create TCP server socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,1\r\n");
 	clear_captured_response();
 
@@ -878,16 +879,16 @@ void test_xlisten_read_command(void)
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_len(__LINE__);
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_fmt(__LINE__);
 	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
-	__cmock_nrf_inet_pton_ExpectAnyArgsAndReturn(1);
-	__cmock_nrf_bind_ExpectAndReturn(3, NULL, sizeof(struct nrf_sockaddr_in), 0);
-	__cmock_nrf_bind_IgnoreArg_address();
-	__cmock_nrf_bind_IgnoreArg_address_len();
+	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
+	__cmock_zsock_bind_ExpectAndReturn(3, NULL, sizeof(struct sockaddr_in), 0);
+	__cmock_zsock_bind_IgnoreArg_addr();
+	__cmock_zsock_bind_IgnoreArg_addrlen();
 	send_at_command("AT#XBIND=3,9000\r\n");
 	clear_captured_response();
 
 	/* Put socket in listening mode */
-	__cmock_nrf_fcntl_ExpectAndReturn(3, NRF_F_SETFL, NRF_O_NONBLOCK, 0);
-	__cmock_nrf_listen_ExpectAndReturn(3, 2, 0);
+	__cmock_zsock_fcntl_wrapper_ExpectAndReturn(3, F_SETFL, 0);
+	__cmock_zsock_listen_ExpectAndReturn(3, 2, 0);
 	send_at_command("AT#XLISTEN=3\r\n");
 	clear_captured_response();
 
@@ -901,7 +902,7 @@ void test_xlisten_read_command(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -914,9 +915,9 @@ void test_xlisten_not_bound(void)
 	const char *response;
 
 	/* Create TCP server socket but don't bind it */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,1\r\n");
 	clear_captured_response();
 
@@ -928,7 +929,7 @@ void test_xlisten_not_bound(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 
@@ -943,9 +944,9 @@ void test_xaccept_operation(void)
 	const char *cgpaddr_resp = "+CGPADDR: 0,\"10.0.0.1\",\"\"\r\nOK\r\n";
 
 	/* Create TCP server socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,1\r\n");
 	clear_captured_response();
 
@@ -956,25 +957,25 @@ void test_xaccept_operation(void)
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_len(__LINE__);
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_fmt(__LINE__);
 	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
-	__cmock_nrf_inet_pton_ExpectAnyArgsAndReturn(1);
-	__cmock_nrf_bind_ExpectAndReturn(1, NULL, sizeof(struct nrf_sockaddr_in), 0);
-	__cmock_nrf_bind_IgnoreArg_address();
-	__cmock_nrf_bind_IgnoreArg_address_len();
+	__cmock_zsock_inet_pton_ExpectAnyArgsAndReturn(1);
+	__cmock_zsock_bind_ExpectAndReturn(1, NULL, sizeof(struct sockaddr_in), 0);
+	__cmock_zsock_bind_IgnoreArg_addr();
+	__cmock_zsock_bind_IgnoreArg_addrlen();
 	send_at_command("AT#XBIND=1,7000\r\n");
 	clear_captured_response();
 
 	/* Put socket in listening mode */
-	__cmock_nrf_fcntl_ExpectAndReturn(1, NRF_F_SETFL, NRF_O_NONBLOCK, 0);
-	__cmock_nrf_listen_ExpectAndReturn(1, 2, 0);
+	__cmock_zsock_fcntl_wrapper_ExpectAndReturn(1, F_SETFL, 0);
+	__cmock_zsock_listen_ExpectAndReturn(1, 2, 0);
 	send_at_command("AT#XLISTEN=1\r\n");
 	clear_captured_response();
 
 	/* Mock successful accept - returns new socket fd=7 with peer info */
 	/* Use callback to properly populate the address structure */
-	__cmock_nrf_accept_Stub(mock_nrf_accept_with_peer_callback);
+	__cmock_zsock_accept_Stub(mock_zsock_accept_with_peer_callback);
 	__cmock_zsock_inet_ntop_Stub(mock_zsock_inet_ntop_192_168_0_100_callback);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB for new socket */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB restore for listening socket */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB for new socket */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB for listening socket */
 
 	/* Execute accept command */
 	send_at_command("AT#XACCEPT=1\r\n");
@@ -986,9 +987,9 @@ void test_xaccept_operation(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close sockets */
-	__cmock_nrf_close_ExpectAndReturn(7, 0);
+	__cmock_zsock_close_ExpectAndReturn(7, 0);
 	send_at_command("AT#XCLOSE=7\r\n");
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -1011,9 +1012,9 @@ void test_xaccept_not_listening(void)
 	clear_captured_response();
 
 	/* Test 2: Create TCP server socket but don't put it in listening mode */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,1\r\n"); /* role=1 (server) */
 	clear_captured_response();
 
@@ -1025,7 +1026,7 @@ void test_xaccept_not_listening(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -1041,16 +1042,16 @@ void test_xsend_unformatted_string(void)
 	int test_data_len = strlen(test_data);
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful send - send all data in one call */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
-	__cmock_nrf_send_ExpectAndReturn(1, NULL, test_data_len, 0, test_data_len);
-	__cmock_nrf_send_IgnoreArg_buffer();
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
+	__cmock_zsock_send_ExpectAndReturn(1, NULL, test_data_len, 0, test_data_len);
+	__cmock_zsock_send_IgnoreArg_buf();
 
 	/* Execute send command: handle=1, mode=0 (unformatted), flags=0 */
 	send_at_command("AT#XSEND=1,0,0,\"Hello World\"\r\n");
@@ -1062,7 +1063,7 @@ void test_xsend_unformatted_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -1078,16 +1079,16 @@ void test_xsend_hex_string(void)
 	int binary_len = 5;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful send - send all data in one call */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
-	__cmock_nrf_send_ExpectAndReturn(4, NULL, binary_len, 0, binary_len);
-	__cmock_nrf_send_IgnoreArg_buffer();
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
+	__cmock_zsock_send_ExpectAndReturn(4, NULL, binary_len, 0, binary_len);
+	__cmock_zsock_send_IgnoreArg_buf();
 
 	/* Execute send command: handle=4, mode=1 (hex), flags=0 */
 	send_at_command("AT#XSEND=4,1,0,\"48656C6C6F\"\r\n");
@@ -1099,7 +1100,7 @@ void test_xsend_hex_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -1115,16 +1116,16 @@ void test_xsend_with_ack_flag(void)
 	int test_data_len = strlen(test_data);
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful send with ACK flag (0x2000 = 8192) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set send callback */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set send callback */
 	/* Note: flags will be 0 after SM_MSG_SEND_ACK (0x2000=8192 not 512!) is stripped */
-	__cmock_nrf_send_ExpectAnyArgsAndReturn(test_data_len);
+	__cmock_zsock_send_ExpectAnyArgsAndReturn(test_data_len);
 
 	/* Execute send command: handle=4, mode=0 (unformatted), flags=8192 (0x2000,
 	 * SM_MSG_SEND_ACK)
@@ -1138,16 +1139,17 @@ void test_xsend_with_ack_flag(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
-/* Helper callback for mocking partial nrf_send */
-static ssize_t mock_nrf_send_partial_callback(int socket, const void *buffer, size_t length,
-					       int flags, int num_calls)
+/* Helper callback for mocking partial zsock_send */
+static ssize_t mock_zsock_send_partial_callback(int sock, const void *buf,
+					       size_t len, int flags,
+					       int cmock_num_calls)
 {
 	/* First call: send 5 bytes out of 13 */
-	if (num_calls == 0) {
+	if (cmock_num_calls == 0) {
 		return 5;
 	}
 	/* Second call: send remaining 8 bytes */
@@ -1156,22 +1158,22 @@ static ssize_t mock_nrf_send_partial_callback(int socket, const void *buffer, si
 
 /*
  * Test: Send data via AT#XSEND with partial send
- * - Tests: Handling when nrf_send() sends less data than requested
+ * - Tests: Handling when zsock_send() sends less data than requested
  */
 void test_xsend_partial_send(void)
 {
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock partial send: first call sends 5 bytes, second call sends remaining 8 bytes */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
-	__cmock_nrf_send_Stub(mock_nrf_send_partial_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
+	__cmock_zsock_send_Stub(mock_zsock_send_partial_callback);
 
 	/* Execute send command: handle=0, mode=0 (unformatted), flags=0 */
 	send_at_command("AT#XSEND=0,0,0,\"HelloWorld123\"\r\n");
@@ -1183,13 +1185,13 @@ void test_xsend_partial_send(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
-/* Helper callback for mocking failed nrf_send with errno */
-static ssize_t mock_nrf_send_error_callback(int socket, const void *buffer, size_t length,
-					    int flags, int num_calls)
+/* Helper callback for mocking failed zsock_send with errno */
+static ssize_t mock_zsock_send_error_callback(int sock, const void *buf, size_t len,
+					      int flags, int cmock_num_calls)
 {
 	/* Set errno to ENOTCONN */
 	errno = ENOTCONN;
@@ -1198,22 +1200,22 @@ static ssize_t mock_nrf_send_error_callback(int socket, const void *buffer, size
 
 /*
  * Test: Send fails with error
- * - Tests: Error handling when nrf_send() fails
+ * - Tests: Error handling when zsock_send() fails
  */
 void test_xsend_error(void)
 {
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock failed send with ENOTCONN error via callback */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
-	__cmock_nrf_send_Stub(mock_nrf_send_error_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
+	__cmock_zsock_send_Stub(mock_zsock_send_error_callback);
 
 	/* Execute send command: should fail */
 	send_at_command("AT#XSEND=4,0,0,\"Test\"\r\n");
@@ -1223,7 +1225,7 @@ void test_xsend_error(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -1238,9 +1240,9 @@ void test_xsend_data_mode(void)
 	const char *test_data = "Hello World";
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
@@ -1254,8 +1256,8 @@ void test_xsend_data_mode(void)
 
 	/* Send data in data mode - this invokes socket_datamode_callback(DATAMODE_SEND) */
 	/* do_send calls clear_so_send_cb (or set if flags have ack) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear/set send callback */
-	__cmock_nrf_send_ExpectAndReturn(1, test_data, 11, 0, 11);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear/set send callback */
+	__cmock_zsock_send_ExpectAndReturn(1, test_data, 11, 0, 11);
 	uart_stub_rx((const uint8_t *)test_data, 11);
 
 	/* Exit data mode with termination pattern */
@@ -1264,7 +1266,7 @@ void test_xsend_data_mode(void)
 	TEST_ASSERT_TRUE(strstr(response, "#XDATAMODE: 0") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -1280,9 +1282,9 @@ void test_xsend_data_mode_partial_quit_string(void)
 	const char *test_data = "Hello++World";
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
@@ -1298,8 +1300,8 @@ void test_xsend_data_mode_partial_quit_string(void)
 	 * The default quit string is "+++" so "++" should be treated as data
 	 * This invokes socket_datamode_callback(DATAMODE_SEND)
 	 */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear/set send callback */
-	__cmock_nrf_send_ExpectAndReturn(1, test_data, 12, 0, 12);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear/set send callback */
+	__cmock_zsock_send_ExpectAndReturn(1, test_data, 12, 0, 12);
 	uart_stub_rx((const uint8_t *)test_data, 12);
 
 	/* Exit data mode with full quit string (+++) */
@@ -1308,7 +1310,7 @@ void test_xsend_data_mode_partial_quit_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "#XDATAMODE: 0") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -1324,9 +1326,9 @@ void test_xsendto_unformatted_string(void)
 	int test_data_len = strlen(test_data);
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
@@ -1336,11 +1338,11 @@ void test_xsendto_unformatted_string(void)
 	__cmock_zsock_freeaddrinfo_IgnoreArg_ai();
 
 	/* Mock successful sendto - send all data in one call */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
-	__cmock_nrf_sendto_ExpectAndReturn(4, NULL, test_data_len, 0, NULL,
-					   sizeof(struct nrf_sockaddr_in), test_data_len);
-	__cmock_nrf_sendto_IgnoreArg_message();
-	__cmock_nrf_sendto_IgnoreArg_dest_addr();
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
+	__cmock_zsock_sendto_ExpectAndReturn(4, NULL, test_data_len, 0, NULL,
+					   sizeof(struct sockaddr_in), test_data_len);
+	__cmock_zsock_sendto_IgnoreArg_buf();
+	__cmock_zsock_sendto_IgnoreArg_dest_addr();
 
 	/* Execute sendto command: handle=4, mode=0 (unformatted), flags=0 */
 	send_at_command("AT#XSENDTO=4,0,0,\"192.168.1.1\",5000,\"Hello UDP\"\r\n");
@@ -1352,7 +1354,7 @@ void test_xsendto_unformatted_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -1368,9 +1370,9 @@ void test_xsendto_hex_string(void)
 	int binary_len = 5;
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
@@ -1380,11 +1382,11 @@ void test_xsendto_hex_string(void)
 	__cmock_zsock_freeaddrinfo_IgnoreArg_ai();
 
 	/* Mock successful sendto - send all data in one call */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
-	__cmock_nrf_sendto_ExpectAndReturn(3, NULL, binary_len, 0, NULL,
-					   sizeof(struct nrf_sockaddr_in), binary_len);
-	__cmock_nrf_sendto_IgnoreArg_message();
-	__cmock_nrf_sendto_IgnoreArg_dest_addr();
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
+	__cmock_zsock_sendto_ExpectAndReturn(3, NULL, binary_len, 0, NULL,
+					   sizeof(struct sockaddr_in), binary_len);
+	__cmock_zsock_sendto_IgnoreArg_buf();
+	__cmock_zsock_sendto_IgnoreArg_dest_addr();
 
 	/* Execute sendto command: handle=3, mode=1 (hex), flags=0 */
 	send_at_command("AT#XSENDTO=3,1,0,\"192.168.1.1\",5000,\"48656C6C6F\"\r\n");
@@ -1396,7 +1398,7 @@ void test_xsendto_hex_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -1412,9 +1414,9 @@ void test_xsendto_with_ack_flag(void)
 	int test_data_len = strlen(test_data);
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
@@ -1424,9 +1426,9 @@ void test_xsendto_with_ack_flag(void)
 	__cmock_zsock_freeaddrinfo_IgnoreArg_ai();
 
 	/* Mock successful sendto with ACK flag (0x2000 = 8192) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set send callback */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set send callback */
 	/* Note: flags will be 0 after SM_MSG_SEND_ACK (0x2000=8192) is stripped */
-	__cmock_nrf_sendto_ExpectAnyArgsAndReturn(test_data_len);
+	__cmock_zsock_sendto_ExpectAnyArgsAndReturn(test_data_len);
 
 	/* Execute sendto command: handle=1, mode=0 (unformatted), flags=8192 (0x2000,
 	 * SM_MSG_SEND_ACK)
@@ -1441,14 +1443,14 @@ void test_xsendto_with_ack_flag(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
-/* Helper callback for mocking failed nrf_sendto with errno */
-static ssize_t mock_nrf_sendto_error_callback(int socket, const void *message, size_t length,
-					      int flags, const struct nrf_sockaddr *dest_addr,
-					      nrf_socklen_t dest_len, int num_calls)
+/* Helper callback for mocking failed zsock_sendto with errno */
+static ssize_t mock_zsock_sendto_dest_error_callback(int sock, const void *buf, size_t len,
+					      int flags, const struct net_sockaddr *dest_addr,
+					      net_socklen_t addrlen, int cmock_num_calls)
 {
 	/* Set errno to ENETUNREACH */
 	errno = ENETUNREACH;
@@ -1457,16 +1459,16 @@ static ssize_t mock_nrf_sendto_error_callback(int socket, const void *message, s
 
 /*
  * Test: Sendto fails with error
- * - Tests: Error handling when nrf_sendto() fails
+ * - Tests: Error handling when zsock_sendto() fails
  */
 void test_xsendto_error(void)
 {
 	const char *response;
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
@@ -1476,8 +1478,8 @@ void test_xsendto_error(void)
 	__cmock_zsock_freeaddrinfo_IgnoreArg_ai();
 
 	/* Mock failed sendto with ENETUNREACH error via callback */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
-	__cmock_nrf_sendto_Stub(mock_nrf_sendto_error_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
+	__cmock_zsock_sendto_Stub(mock_zsock_sendto_dest_error_callback);
 
 	/* Execute sendto command: should fail */
 	send_at_command("AT#XSENDTO=3,0,0,\"192.168.1.1\",5000,\"Test\"\r\n");
@@ -1487,7 +1489,7 @@ void test_xsendto_error(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -1503,9 +1505,9 @@ void test_xsendto_ipv6(void)
 	int test_data_len = strlen(test_data);
 
 	/* Create IPv6 UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=2,2,0\r\n");
 	clear_captured_response();
 
@@ -1515,12 +1517,12 @@ void test_xsendto_ipv6(void)
 	__cmock_zsock_freeaddrinfo_IgnoreArg_ai();
 
 	/* Mock successful sendto - send all data in one call */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
-	__cmock_nrf_sendto_ExpectAndReturn(4, NULL, test_data_len, 0, NULL,
-					   sizeof(struct nrf_sockaddr_in6), test_data_len);
-	__cmock_nrf_sendto_IgnoreArg_message();
-	__cmock_nrf_sendto_IgnoreArg_dest_addr();
-	__cmock_nrf_sendto_IgnoreArg_dest_len();
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear send callback */
+	__cmock_zsock_sendto_ExpectAndReturn(4, NULL, test_data_len, 0, NULL,
+					   sizeof(struct net_sockaddr_in6), test_data_len);
+	__cmock_zsock_sendto_IgnoreArg_buf();
+	__cmock_zsock_sendto_IgnoreArg_dest_addr();
+	__cmock_zsock_sendto_IgnoreArg_addrlen();
 
 	/* Execute sendto command: handle=4, mode=0 (unformatted), flags=0 */
 	send_at_command("AT#XSENDTO=4,0,0,\"2001:db8::1\",5000,\"IPv6 Test\"\r\n");
@@ -1532,7 +1534,7 @@ void test_xsendto_ipv6(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -1547,9 +1549,9 @@ void test_xsendto_data_mode(void)
 	const char *test_data = "Hello World";
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
@@ -1563,9 +1565,9 @@ void test_xsendto_data_mode(void)
 
 	/* Send data in data mode - this invokes socket_datamode_callback(DATAMODE_SEND) */
 	/* do_sendto calls clear_so_send_cb (or set if flags have ack) and DNS resolution */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear/set send callback */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Clear/set send callback */
 	__cmock_zsock_getaddrinfo_Stub(mock_getaddrinfo_success_callback);
-	__cmock_nrf_sendto_ExpectAnyArgsAndReturn(11);
+	__cmock_zsock_sendto_ExpectAnyArgsAndReturn(11);
 	__cmock_zsock_freeaddrinfo_ExpectAnyArgs();
 	uart_stub_rx((const uint8_t *)test_data, 11);
 
@@ -1575,19 +1577,19 @@ void test_xsendto_data_mode(void)
 	TEST_ASSERT_TRUE(strstr(response, "#XDATAMODE: 0") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 
-/* Helper callback for mocking nrf_recv with data */
-static ssize_t mock_nrf_recv_callback(int socket, void *buffer, size_t length, int flags,
-				      int num_calls)
+/* Helper callback for mocking zsock_recv with data */
+static ssize_t mock_zsock_recv_callback(int sock, void *buf, size_t max_len, int flags,
+				      int cmock_num_calls)
 {
 	const char *test_data = "Hello from recv";
 	size_t data_len = strlen(test_data);
 
-	if (length >= data_len) {
-		memcpy(buffer, test_data, data_len);
+	if (max_len >= data_len) {
+		memcpy(buf, test_data, data_len);
 		return data_len;
 	}
 	return -1;
@@ -1603,16 +1605,16 @@ void test_xrecv_unformatted_string(void)
 	const char *response;
 
 	/* Create TCP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful recv - receive data */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recv_Stub(mock_nrf_recv_callback);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recv_Stub(mock_zsock_recv_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
 
 	/* Execute recv command: handle=0, mode=0 (unformatted), flags=0, timeout=5 */
 	send_at_command("AT#XRECV=0,0,0,5\r\n");
@@ -1625,20 +1627,20 @@ void test_xrecv_unformatted_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
-/* Helper callback for mocking nrf_recv with hex data */
-static ssize_t mock_nrf_recv_hex_callback(int socket, void *buffer, size_t length, int flags,
-					  int num_calls)
+/* Helper callback for mocking zsock_recv with hex data */
+static ssize_t mock_zsock_recv_hex_callback(int sock, void *buf, size_t max_len, int flags,
+					  int cmock_num_calls)
 {
 	/* Return binary data: 0x48 0x65 0x6C 0x6C 0x6F = "Hello" */
 	const uint8_t test_data[] = {0x48, 0x65, 0x6C, 0x6C, 0x6F};
 	size_t data_len = sizeof(test_data);
 
-	if (length >= data_len) {
-		memcpy(buffer, test_data, data_len);
+	if (max_len >= data_len) {
+		memcpy(buf, test_data, data_len);
 		return data_len;
 	}
 	return -1;
@@ -1654,16 +1656,16 @@ void test_xrecv_hex_string(void)
 	const char *response;
 
 	/* Create TCP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful recv - receive binary data */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recv_Stub(mock_nrf_recv_hex_callback);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recv_Stub(mock_zsock_recv_hex_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
 
 	/* Execute recv command: handle=1, mode=1 (hex), flags=0, timeout=5 */
 	send_at_command("AT#XRECV=1,1,0,5\r\n");
@@ -1677,20 +1679,20 @@ void test_xrecv_hex_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
-/* Helper callback for mocking nrf_recv with limited data */
-static ssize_t mock_nrf_recv_limited_callback(int socket, void *buffer, size_t length, int flags,
-					      int num_calls)
+/* Helper callback for mocking zsock_recv with limited data */
+static ssize_t mock_zsock_recv_limited_callback(int sock, void *buf, size_t max_len, int flags,
+					      int cmock_num_calls)
 {
 	/* Return only 10 bytes even though more could be received */
 	const char *test_data = "0123456789";
 	size_t data_len = 10;
 
-	if (length >= data_len) {
-		memcpy(buffer, test_data, data_len);
+	if (max_len >= data_len) {
+		memcpy(buf, test_data, data_len);
 		return data_len;
 	}
 	return -1;
@@ -1706,16 +1708,16 @@ void test_xrecv_with_data_len(void)
 	const char *response;
 
 	/* Create TCP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful recv - receive limited data */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recv_Stub(mock_nrf_recv_limited_callback);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recv_Stub(mock_zsock_recv_limited_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
 
 	/* Execute recv command: handle=3, mode=0, flags=0, timeout=5, data_len=10 */
 	send_at_command("AT#XRECV=3,0,0,5,10\r\n");
@@ -1728,13 +1730,13 @@ void test_xrecv_with_data_len(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
-/* Helper callback for mocking failed nrf_recv with errno */
-static ssize_t mock_nrf_recv_error_callback(int socket, void *buffer, size_t length, int flags,
-					    int num_calls)
+/* Helper callback for mocking failed zsock_recv with errno */
+static ssize_t mock_zsock_recv_error_callback(int sock, void *buf, size_t max_len, int flags,
+					    int cmock_num_calls)
 {
 	/* Set errno to EAGAIN (timeout) */
 	errno = EAGAIN;
@@ -1743,22 +1745,22 @@ static ssize_t mock_nrf_recv_error_callback(int socket, void *buffer, size_t len
 
 /*
  * Test: Recv fails with error (timeout)
- * - Tests: Error handling when nrf_recv() fails
+ * - Tests: Error handling when zsock_recv() fails
  */
 void test_xrecv_timeout(void)
 {
 	const char *response;
 
 	/* Create TCP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock failed recv with EAGAIN error via callback */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recv_Stub(mock_nrf_recv_error_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recv_Stub(mock_zsock_recv_error_callback);
 	/* No poll event update mock needed since recv fails */
 
 	/* Execute recv command: should timeout */
@@ -1769,13 +1771,13 @@ void test_xrecv_timeout(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 
-/* Helper callback for mocking nrf_recv returning zero (connection closed) */
-static ssize_t mock_nrf_recv_zero_callback(int socket, void *buffer, size_t length, int flags,
-					   int num_calls)
+/* Helper callback for mocking zsock_recv returning zero (connection closed) */
+static ssize_t mock_zsock_recv_zero_callback(int sock, void *buf, size_t max_len, int flags,
+					   int cmock_num_calls)
 {
 	/* Return 0 to indicate connection closed */
 	return 0;
@@ -1783,22 +1785,22 @@ static ssize_t mock_nrf_recv_zero_callback(int socket, void *buffer, size_t leng
 
 /*
  * Test: Recv returns zero (connection closed)
- * - Tests: Handling when nrf_recv() returns 0 (peer closed connection)
+ * - Tests: Handling when zsock_recv() returns 0 (peer closed connection)
  */
 void test_xrecv_connection_closed(void)
 {
 	const char *response;
 
 	/* Create TCP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Mock recv returning 0 (connection closed) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recv_Stub(mock_nrf_recv_zero_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recv_Stub(mock_zsock_recv_zero_callback);
 
 	/* Execute recv command */
 	send_at_command("AT#XRECV=2,0,0,5\r\n");
@@ -1810,7 +1812,7 @@ void test_xrecv_connection_closed(void)
 	TEST_ASSERT_TRUE(strstr(response, "#XRECV:") == NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 
@@ -1818,9 +1820,9 @@ void test_xrecv_connection_closed(void)
 static char *mock_zsock_inet_ntop_callback(
 	net_sa_family_t af, const void *src, char *dst, net_socklen_t size, int num_calls)
 {
-	if (af == NRF_AF_INET) {
+	if (af == AF_INET) {
 		strcpy(dst, "192.168.0.1");
-	} else if (af == NRF_AF_INET6) {
+	} else if (af == AF_INET6) {
 		strcpy(dst, "2001:db8::1");
 	}
 	return dst;
@@ -1834,22 +1836,22 @@ static char *mock_zsock_inet_ntop_10_0_0_1_callback(
 	return dst;
 }
 
-/* Helper callback for mocking nrf_recvfrom with data and address */
-static ssize_t mock_nrf_recvfrom_callback(int socket, void *buffer, size_t length, int flags,
-					  struct nrf_sockaddr *address, nrf_socklen_t *address_len,
-					  int num_calls)
+/* Helper callback for mocking zsock_recvfrom with data and address */
+static ssize_t mock_zsock_recvfrom_callback(int sock, void *buf, size_t max_len, int flags,
+					  struct net_sockaddr *src_addr, net_socklen_t *addrlen,
+					  int cmock_num_calls)
 {
 	const char *test_data = "UDP data";
 	size_t data_len = strlen(test_data);
-	struct nrf_sockaddr_in *sa_in = (struct nrf_sockaddr_in *)address;
+	struct net_sockaddr_in *sa_in = (struct net_sockaddr_in *)src_addr;
 
-	if (length >= data_len) {
-		memcpy(buffer, test_data, data_len);
+	if (max_len >= data_len) {
+		memcpy(buf, test_data, data_len);
 		/* Set up source address */
-		sa_in->sin_family = NRF_AF_INET;
+		sa_in->sin_family = AF_INET;
 		sa_in->sin_port = net_htons(8080);
 		sa_in->sin_addr.s_addr = net_htonl(0xC0A80001); /* 192.168.0.1 */
-		*address_len = sizeof(struct nrf_sockaddr_in);
+		*addrlen = sizeof(struct sockaddr_in);
 		return data_len;
 	}
 	return -1;
@@ -1865,17 +1867,17 @@ void test_xrecvfrom_unformatted_string(void)
 	const char *response;
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful recvfrom - receive data with source address */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recvfrom_Stub(mock_nrf_recvfrom_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recvfrom_Stub(mock_zsock_recvfrom_callback);
 	__cmock_zsock_inet_ntop_Stub(mock_zsock_inet_ntop_callback);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
 
 	/* Execute recvfrom command: handle=1, mode=0 (unformatted), flags=0, timeout=5 */
 	send_at_command("AT#XRECVFROM=1,0,0,5\r\n");
@@ -1890,27 +1892,27 @@ void test_xrecvfrom_unformatted_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
-/* Helper callback for mocking nrf_recvfrom with hex data */
-static ssize_t mock_nrf_recvfrom_hex_callback(int socket, void *buffer, size_t length, int flags,
-					      struct nrf_sockaddr *address,
-					      nrf_socklen_t *address_len, int num_calls)
+/* Helper callback for mocking zsock_recvfrom with hex data */
+static ssize_t mock_zsock_recvfrom_hex_callback(int sock, void *buf, size_t max_len, int flags,
+					      struct net_sockaddr *src_addr,
+					      net_socklen_t *addrlen, int cmock_num_calls)
 {
 	/* Return binary data: 0x48 0x65 0x6C 0x6C 0x6F = "Hello" */
 	const uint8_t test_data[] = {0x48, 0x65, 0x6C, 0x6C, 0x6F};
 	size_t data_len = sizeof(test_data);
-	struct nrf_sockaddr_in *sa_in = (struct nrf_sockaddr_in *)address;
+	struct net_sockaddr_in *sa_in = (struct net_sockaddr_in *)src_addr;
 
-	if (length >= data_len) {
-		memcpy(buffer, test_data, data_len);
+	if (max_len >= data_len) {
+		memcpy(buf, test_data, data_len);
 		/* Set up source address */
-		sa_in->sin_family = NRF_AF_INET;
+		sa_in->sin_family = AF_INET;
 		sa_in->sin_port = net_htons(9000);
 		sa_in->sin_addr.s_addr = net_htonl(0x0A000001); /* 10.0.0.1 */
-		*address_len = sizeof(struct nrf_sockaddr_in);
+		*addrlen = sizeof(struct sockaddr_in);
 		return data_len;
 	}
 	return -1;
@@ -1926,17 +1928,17 @@ void test_xrecvfrom_hex_string(void)
 	const char *response;
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful recvfrom - receive binary data */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recvfrom_Stub(mock_nrf_recvfrom_hex_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recvfrom_Stub(mock_zsock_recvfrom_hex_callback);
 	__cmock_zsock_inet_ntop_Stub(mock_zsock_inet_ntop_10_0_0_1_callback);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
 
 	/* Execute recvfrom command: handle=1, mode=1 (hex), flags=0, timeout=5 */
 	send_at_command("AT#XRECVFROM=1,1,0,5\r\n");
@@ -1951,26 +1953,26 @@ void test_xrecvfrom_hex_string(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
-/* Helper callback for mocking nrf_recvfrom with IPv6 address */
-static ssize_t mock_nrf_recvfrom_ipv6_callback(int socket, void *buffer, size_t length, int flags,
-					       struct nrf_sockaddr *address,
-					       nrf_socklen_t *address_len, int num_calls)
+/* Helper callback for mocking zsock_recvfrom with IPv6 address */
+static ssize_t mock_zsock_recvfrom_ipv6_callback(int sock, void *buf, size_t max_len, int flags,
+					       struct net_sockaddr *src_addr,
+					       net_socklen_t *addrlen, int cmock_num_calls)
 {
 	const char *test_data = "IPv6 UDP";
 	size_t data_len = strlen(test_data);
-	struct nrf_sockaddr_in6 *sa_in6 = (struct nrf_sockaddr_in6 *)address;
+	struct net_sockaddr_in6 *sa_in6 = (struct net_sockaddr_in6 *)src_addr;
 
-	if (length >= data_len) {
-		memcpy(buffer, test_data, data_len);
+	if (max_len >= data_len) {
+		memcpy(buf, test_data, data_len);
 		/* Set up IPv6 source address */
-		sa_in6->sin6_family = NRF_AF_INET6;
+		sa_in6->sin6_family = AF_INET6;
 		sa_in6->sin6_port = net_htons(7000);
 		/* 2001:db8::1 */
-		*address_len = sizeof(struct nrf_sockaddr_in6);
+		*addrlen = sizeof(struct net_sockaddr_in6);
 		return data_len;
 	}
 	return -1;
@@ -1986,17 +1988,17 @@ void test_xrecvfrom_ipv6(void)
 	const char *response;
 
 	/* Create IPv6 UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=2,2,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful recvfrom - receive data with IPv6 source address */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recvfrom_Stub(mock_nrf_recvfrom_ipv6_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recvfrom_Stub(mock_zsock_recvfrom_ipv6_callback);
 	__cmock_zsock_inet_ntop_Stub(mock_zsock_inet_ntop_callback);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
 
 	/* Execute recvfrom command: handle=2, mode=0, flags=0, timeout=5 */
 	send_at_command("AT#XRECVFROM=2,0,0,5\r\n");
@@ -2011,27 +2013,27 @@ void test_xrecvfrom_ipv6(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 
-/* Helper callback for mocking nrf_recvfrom with limited data */
-static ssize_t mock_nrf_recvfrom_limited_callback(int socket, void *buffer, size_t length,
-						   int flags, struct nrf_sockaddr *address,
-						   nrf_socklen_t *address_len, int num_calls)
+/* Helper callback for mocking zsock_recvfrom with limited data */
+static ssize_t mock_zsock_recvfrom_limited_callback(int sock, void *buf, size_t max_len,
+						   int flags, struct net_sockaddr *src_addr,
+						   net_socklen_t *addrlen, int cmock_num_calls)
 {
 	/* Return only 10 bytes */
 	const char *test_data = "0123456789";
 	size_t data_len = 10;
-	struct nrf_sockaddr_in *sa_in = (struct nrf_sockaddr_in *)address;
+	struct net_sockaddr_in *sa_in = (struct net_sockaddr_in *)src_addr;
 
-	if (length >= data_len) {
-		memcpy(buffer, test_data, data_len);
+	if (max_len >= data_len) {
+		memcpy(buf, test_data, data_len);
 		/* Set up source address */
-		sa_in->sin_family = NRF_AF_INET;
+		sa_in->sin_family = AF_INET;
 		sa_in->sin_port = net_htons(5000);
 		sa_in->sin_addr.s_addr = net_htonl(0xC0A80064); /* 192.168.0.100 */
-		*address_len = sizeof(struct nrf_sockaddr_in);
+		*addrlen = sizeof(struct sockaddr_in);
 		return data_len;
 	}
 	return -1;
@@ -2047,17 +2049,17 @@ void test_xrecvfrom_with_data_len(void)
 	const char *response;
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
 	/* Mock successful recvfrom - receive limited data */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recvfrom_Stub(mock_nrf_recvfrom_limited_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recvfrom_Stub(mock_zsock_recvfrom_limited_callback);
 	__cmock_zsock_inet_ntop_Stub(mock_zsock_inet_ntop_192_168_0_100_callback);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Poll event update */
 
 	/* Execute recvfrom command: handle=0, mode=0, flags=0, timeout=5, data_len=10 */
 	send_at_command("AT#XRECVFROM=0,0,0,5,10\r\n");
@@ -2072,14 +2074,14 @@ void test_xrecvfrom_with_data_len(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
-/* Helper callback for mocking failed nrf_recvfrom with errno */
-static ssize_t mock_nrf_recvfrom_error_callback(int socket, void *buffer, size_t length, int flags,
-						struct nrf_sockaddr *address,
-						nrf_socklen_t *address_len, int num_calls)
+/* Helper callback for mocking failed zsock_recvfrom with errno */
+static ssize_t mock_zsock_recvfrom_error_callback(int sock, void *buf, size_t max_len, int flags,
+						struct net_sockaddr *src_addr,
+						net_socklen_t *addrlen, int cmock_num_calls)
 {
 	/* Set errno to EAGAIN (timeout) */
 	errno = EAGAIN;
@@ -2088,22 +2090,22 @@ static ssize_t mock_nrf_recvfrom_error_callback(int socket, void *buffer, size_t
 
 /*
  * Test: Recvfrom fails with error (timeout)
- * - Tests: Error handling when nrf_recvfrom() fails
+ * - Tests: Error handling when zsock_recvfrom() fails
  */
 void test_xrecvfrom_timeout(void)
 {
 	const char *response;
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
 	/* Mock failed recvfrom with EAGAIN error via callback */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recvfrom_Stub(mock_nrf_recvfrom_error_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recvfrom_Stub(mock_zsock_recvfrom_error_callback);
 	/* No poll event update mock needed since recvfrom fails */
 
 	/* Execute recvfrom command: should timeout */
@@ -2114,43 +2116,43 @@ void test_xrecvfrom_timeout(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
-/* Helper callback for mocking nrf_recvfrom returning zero (datagram received) */
-static ssize_t mock_nrf_recvfrom_zero_callback(int socket, void *buffer, size_t length, int flags,
-					       struct nrf_sockaddr *address,
-					       nrf_socklen_t *address_len, int num_calls)
+/* Helper callback for mocking zsock_recvfrom returning zero (datagram received) */
+static ssize_t mock_zsock_recvfrom_zero_callback(int sock, void *buf, size_t max_len, int flags,
+					       struct net_sockaddr *src_addr,
+					       net_socklen_t *addrlen, int cmock_num_calls)
 {
 	/* Return 0 to indicate zero-length datagram received */
-	struct nrf_sockaddr_in *sa_in = (struct nrf_sockaddr_in *)address;
+	struct net_sockaddr_in *sa_in = (struct net_sockaddr_in *)src_addr;
 
-	sa_in->sin_family = NRF_AF_INET;
+	sa_in->sin_family = AF_INET;
 	sa_in->sin_port = net_htons(3000);
 	sa_in->sin_addr.s_addr = net_htonl(0xC0A80002); /* 192.168.0.2 */
-	*address_len = sizeof(struct nrf_sockaddr_in);
+	*addrlen = sizeof(struct sockaddr_in);
 	return 0;
 }
 
 /*
  * Test: Recvfrom returns zero (zero-length datagram)
- * - Tests: Handling when nrf_recvfrom() returns 0 (zero-length datagram)
+ * - Tests: Handling when zsock_recvfrom() returns 0 (zero-length datagram)
  */
 void test_xrecvfrom_zero_length(void)
 {
 	const char *response;
 
 	/* Create UDP socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	clear_captured_response();
 
 	/* Mock recvfrom returning 0 (zero-length datagram) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
-	__cmock_nrf_recvfrom_Stub(mock_nrf_recvfrom_zero_callback);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Set receive timeout */
+	__cmock_zsock_recvfrom_Stub(mock_zsock_recvfrom_zero_callback);
 
 	/* Execute recvfrom command */
 	send_at_command("AT#XRECVFROM=3,0,0,5\r\n");
@@ -2162,7 +2164,7 @@ void test_xrecvfrom_zero_length(void)
 	TEST_ASSERT_TRUE(strstr(response, "#XRECVFROM:") == NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -2176,14 +2178,14 @@ void test_xapoll_start_pollin(void)
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB - initial setup */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB - initial setup */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Start async polling for POLLIN (value 1) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB - update for xapoll */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB - update for xapoll */
 	send_at_command("AT#XAPOLL=0,1,1\r\n");
 
 	/* Verify OK response */
@@ -2191,7 +2193,7 @@ void test_xapoll_start_pollin(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -2205,14 +2207,14 @@ void test_xapoll_start_pollout(void)
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Start async polling for POLLOUT (value 4) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
 	send_at_command("AT#XAPOLL=2,1,4\r\n");
 
 	/* Verify OK response */
@@ -2220,7 +2222,7 @@ void test_xapoll_start_pollout(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 
@@ -2234,14 +2236,14 @@ void test_xapoll_start_pollin_pollout(void)
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Start async polling for POLLIN | POLLOUT (value 5) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
 	send_at_command("AT#XAPOLL=2,1,5\r\n");
 
 	/* Verify OK response */
@@ -2249,7 +2251,7 @@ void test_xapoll_start_pollin_pollout(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 
@@ -2263,14 +2265,14 @@ void test_xapoll_stop_socket(void)
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Start async polling first */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
 	send_at_command("AT#XAPOLL=4,1,1\r\n");
 	clear_captured_response();
 
@@ -2282,7 +2284,7 @@ void test_xapoll_stop_socket(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -2298,17 +2300,17 @@ void test_xapoll_start_all_sockets(void)
 
 	/* Create multiple sockets */
 	for (int i = 0; i < max_sockets; i++) {
-		__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP,
+		__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP,
 						   i);
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 		send_at_command("AT#XSOCKET=1,1,0\r\n");
 		clear_captured_response();
 	}
 
 	/* Start async polling for all sockets (no handle specified) */
 	for (int i = 0; i < max_sockets; i++) {
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
 	}
 	send_at_command("AT#XAPOLL=,1,1\r\n");
 
@@ -2319,7 +2321,7 @@ void test_xapoll_start_all_sockets(void)
 	/* Close all sockets */
 	for (int i = 0; i < max_sockets; i++) {
 		char send_buf[20];
-		__cmock_nrf_close_ExpectAndReturn(i, 0);
+		__cmock_zsock_close_ExpectAndReturn(i, 0);
 		sprintf(send_buf, "AT#XCLOSE=%d\r\n", i);
 		send_at_command(send_buf);
 	}
@@ -2337,17 +2339,17 @@ void test_xapoll_stop_all_sockets(void)
 
 	/* Create multiple sockets */
 	for (int i = 0; i < max_sockets; i++) {
-		__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP,
+		__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP,
 						   i);
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 		send_at_command("AT#XSOCKET=1,1,0\r\n");
 		clear_captured_response();
 	}
 
 	/* Start async polling for all sockets first */
 	for (int i = 0; i < max_sockets; i++) {
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
 	}
 	send_at_command("AT#XAPOLL=,1,1\r\n");
 	clear_captured_response();
@@ -2362,7 +2364,7 @@ void test_xapoll_stop_all_sockets(void)
 	/* Close all sockets */
 	for (int i = 0; i < max_sockets; i++) {
 		char send_buf[20];
-		__cmock_nrf_close_ExpectAndReturn(i, 0);
+		__cmock_zsock_close_ExpectAndReturn(i, 0);
 		sprintf(send_buf, "AT#XCLOSE=%d\r\n", i);
 		send_at_command(send_buf);
 	}
@@ -2378,14 +2380,14 @@ void test_xapoll_read(void)
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Start async polling for POLLIN */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Update poll events */
 	send_at_command("AT#XAPOLL=2,1,1\r\n");
 	clear_captured_response();
 
@@ -2399,7 +2401,7 @@ void test_xapoll_read(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 
@@ -2433,9 +2435,9 @@ void test_xapoll_invalid_events(void)
 	const char *response;
 
 	/* Create socket first */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
@@ -2447,7 +2449,7 @@ void test_xapoll_invalid_events(void)
 	TEST_ASSERT_TRUE(strstr(response, "ERROR") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -2481,14 +2483,14 @@ void test_xclose_operation(void)
 
 	/* Test 1: Close single socket using handle */
 	/* Create one socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	clear_captured_response();
 
 	/* Close it using handle */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 	send_at_command("AT#XCLOSE=3\r\n");
 
@@ -2501,17 +2503,17 @@ void test_xclose_operation(void)
 	/* Test 2: Close several sockets with one call without handle */
 	/* Create multiple sockets (maximum allowed) */
 	for (int i = 0; i < max_sockets; i++) {
-		__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP,
+		__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP,
 						   i);
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
-		__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
+		__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 		send_at_command("AT#XSOCKET=1,1,0\r\n");
 		clear_captured_response();
 	}
 
 	/* Close all sockets with one command (no handle parameter) */
 	for (int i = 0; i < max_sockets; i++) {
-		__cmock_nrf_close_ExpectAndReturn(i, 0);
+		__cmock_zsock_close_ExpectAndReturn(i, 0);
 	}
 	send_at_command("AT#XCLOSE\r\n");
 
@@ -2526,64 +2528,64 @@ void test_xclose_operation(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 }
 
-/* Helper callback for mocking nrf_inet_ntop (IPv4) */
-static const char *mock_nrf_inet_ntop_ipv4_callback(int af, const void *src, char *dst,
-						    nrf_socklen_t size, int num_calls)
+/* Helper callback for mocking zsock_inet_ntop (IPv4) */
+static char *mock_zsock_inet_ntop_ipv4_callback(net_sa_family_t af, const void *src, char *dst,
+						    net_socklen_t size, int cmock_num_calls)
 {
 	/* Return the IPv4 address string */
 	strcpy(dst, "192.168.0.1");
 	return dst;
 }
 
-/* Helper callback for mocking nrf_inet_ntop (IPv6) */
-static const char *mock_nrf_inet_ntop_ipv6_callback(int af, const void *src, char *dst,
-						    nrf_socklen_t size, int num_calls)
+/* Helper callback for mocking zsock_inet_ntop (IPv6) */
+static char *mock_zsock_inet_ntop_ipv6_callback(net_sa_family_t af, const void *src, char *dst,
+						    net_socklen_t size, int cmock_num_calls)
 {
 	/* Return the IPv6 address string */
 	strcpy(dst, "2001:db8::1");
 	return dst;
 }
 
-/* Helper callback for mocking successful nrf_getaddrinfo (IPv4) */
-static int mock_nrf_getaddrinfo_ipv4_callback(const char *nodename, const char *servname,
-					      const struct nrf_addrinfo *hints,
-					      struct nrf_addrinfo **res, int num_calls)
+/* Helper callback for mocking successful zsock_getaddrinfo (IPv4) */
+static int mock_zsock_getaddrinfo_ipv4_callback(const char *nodename, const char *servname,
+					      const struct zsock_addrinfo *hints,
+					      struct zsock_addrinfo **res, int cmock_num_calls)
 {
 	static struct {
-		struct nrf_addrinfo ai;
-		struct nrf_sockaddr_in sa;
+		struct zsock_addrinfo ai;
+		struct net_sockaddr_in sa;
 	} result;
 
 	/* Setup IPv4 address */
 	memset(&result, 0, sizeof(result));
-	result.sa.sin_family = NRF_AF_INET;
+	result.sa.sin_family = AF_INET;
 	result.sa.sin_addr.s_addr = net_htonl(0xC0A80001); /* 192.168.0.1 */
 
 	/* Setup addrinfo */
-	result.ai.ai_family = NRF_AF_INET;
-	result.ai.ai_socktype = NRF_SOCK_STREAM;
-	result.ai.ai_protocol = NRF_IPPROTO_TCP;
+	result.ai.ai_family = AF_INET;
+	result.ai.ai_socktype = SOCK_STREAM;
+	result.ai.ai_protocol = IPPROTO_TCP;
 	result.ai.ai_addrlen = sizeof(result.sa);
-	result.ai.ai_addr = (struct nrf_sockaddr *)&result.sa;
+	result.ai.ai_addr = (struct net_sockaddr *)&result.sa;
 	result.ai.ai_next = NULL;
 
 	*res = &result.ai;
 	return 0;
 }
 
-/* Helper callback for mocking successful nrf_getaddrinfo (IPv6) */
-static int mock_nrf_getaddrinfo_ipv6_callback(const char *nodename, const char *servname,
-					      const struct nrf_addrinfo *hints,
-					      struct nrf_addrinfo **res, int num_calls)
+/* Helper callback for mocking successful zsock_getaddrinfo (IPv6) */
+static int mock_zsock_getaddrinfo_ipv6_callback(const char *nodename, const char *servname,
+					      const struct zsock_addrinfo *hints,
+					      struct zsock_addrinfo **res, int cmock_num_calls)
 {
 	static struct {
-		struct nrf_addrinfo ai;
-		struct nrf_sockaddr_in6 sa;
+		struct zsock_addrinfo ai;
+		struct net_sockaddr_in6 sa;
 	} result;
 
 	/* Setup IPv6 address (2001:db8::1) */
 	memset(&result, 0, sizeof(result));
-	result.sa.sin6_family = NRF_AF_INET6;
+	result.sa.sin6_family = AF_INET6;
 	result.sa.sin6_addr.s6_addr[0] = 0x20;
 	result.sa.sin6_addr.s6_addr[1] = 0x01;
 	result.sa.sin6_addr.s6_addr[2] = 0x0d;
@@ -2591,11 +2593,11 @@ static int mock_nrf_getaddrinfo_ipv6_callback(const char *nodename, const char *
 	result.sa.sin6_addr.s6_addr[15] = 0x01;
 
 	/* Setup addrinfo */
-	result.ai.ai_family = NRF_AF_INET6;
-	result.ai.ai_socktype = NRF_SOCK_STREAM;
-	result.ai.ai_protocol = NRF_IPPROTO_TCP;
+	result.ai.ai_family = AF_INET6;
+	result.ai.ai_socktype = SOCK_STREAM;
+	result.ai.ai_protocol = IPPROTO_TCP;
 	result.ai.ai_addrlen = sizeof(result.sa);
-	result.ai.ai_addr = (struct nrf_sockaddr *)&result.sa;
+	result.ai.ai_addr = (struct net_sockaddr *)&result.sa;
 	result.ai.ai_next = NULL;
 
 	*res = &result.ai;
@@ -2611,11 +2613,11 @@ void test_xgetaddrinfo_ipv4(void)
 {
 	const char *response;
 
-	/* Mock nrf_getaddrinfo to succeed with IPv4 address */
-	__cmock_nrf_getaddrinfo_Stub(mock_nrf_getaddrinfo_ipv4_callback);
-	__cmock_nrf_inet_ntop_Stub(mock_nrf_inet_ntop_ipv4_callback);
-	__cmock_nrf_freeaddrinfo_Expect(NULL);
-	__cmock_nrf_freeaddrinfo_IgnoreArg_ai();
+	/* Mock zsock_getaddrinfo to succeed with IPv4 address */
+	__cmock_zsock_getaddrinfo_Stub(mock_zsock_getaddrinfo_ipv4_callback);
+	__cmock_zsock_inet_ntop_Stub(mock_zsock_inet_ntop_ipv4_callback);
+	__cmock_zsock_freeaddrinfo_Expect(NULL);
+	__cmock_zsock_freeaddrinfo_IgnoreArg_ai();
 
 	/* Execute XGETADDRINFO command */
 	send_at_command("AT#XGETADDRINFO=\"example.com\"\r\n");
@@ -2635,13 +2637,13 @@ void test_xgetaddrinfo_ipv6(void)
 {
 	const char *response;
 
-	/* Mock nrf_getaddrinfo to succeed with IPv6 address */
-	__cmock_nrf_getaddrinfo_Stub(mock_nrf_getaddrinfo_ipv6_callback);
-	__cmock_nrf_inet_ntop_Stub(mock_nrf_inet_ntop_ipv6_callback);
-	__cmock_nrf_freeaddrinfo_Expect(NULL);
-	__cmock_nrf_freeaddrinfo_IgnoreArg_ai();
+	/* Mock zsock_getaddrinfo to succeed with IPv6 address */
+	__cmock_zsock_getaddrinfo_Stub(mock_zsock_getaddrinfo_ipv6_callback);
+	__cmock_zsock_inet_ntop_Stub(mock_zsock_inet_ntop_ipv6_callback);
+	__cmock_zsock_freeaddrinfo_Expect(NULL);
+	__cmock_zsock_freeaddrinfo_IgnoreArg_ai();
 
-	/* Execute XGETADDRINFO command with IPv6 family (NRF_AF_INET6 = 2) */
+	/* Execute XGETADDRINFO command with IPv6 family (AF_INET6 = 2) */
 	send_at_command("AT#XGETADDRINFO=\"ipv6.example.com\",2\r\n");
 
 	/* Verify response contains IPv6 address */
@@ -2676,8 +2678,8 @@ void test_xgetaddrinfo_dns_failure(void)
 {
 	const char *response;
 
-	/* Mock nrf_getaddrinfo to fail with DNS_EAI_NONAME */
-	__cmock_nrf_getaddrinfo_ExpectAnyArgsAndReturn(DNS_EAI_NONAME);
+	/* Mock zsock_getaddrinfo to fail with DNS_EAI_NONAME */
+	__cmock_zsock_getaddrinfo_ExpectAnyArgsAndReturn(DNS_EAI_NONAME);
 	__cmock_zsock_gai_strerror_CMockExpectAnyArgsAndReturn(__LINE__,
 							       "Name or service not known");
 
@@ -2700,36 +2702,36 @@ void test_xssocket_read_operation(void)
 	const char *response;
 
 	/* Create first secure socket: IPv4 TLS client (fd=1) */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
-					   258 /* NRF_SPROTO_TLS1v2 */, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM,
+					   IPPROTO_TLS_1_2, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSSOCKET=1,1,0,42\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET: 1") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Create second secure socket: IPv4 DTLS client (fd=2) */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM,
-					   273 /* NRF_SPROTO_DTLS1v2 */, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM,
+					   IPPROTO_DTLS_1_2, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSSOCKET=1,2,0,16842752\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET: 2") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Create third secure socket: IPv6 TLS server (fd=3) */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM,
-					   258 /* NRF_SPROTO_TLS1v2 */, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET6, SOCK_STREAM,
+					   IPPROTO_TLS_1_2, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSSOCKET=2,1,1,42\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET: 3") != NULL);
@@ -2750,11 +2752,11 @@ void test_xssocket_read_operation(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close all sockets */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -2788,16 +2790,16 @@ void test_xssocket_ipv4_tcp_client(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 3 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
-					   258 /* NRF_SPROTO_TLS1v2 */, 3);
+	/* Mock zsock_socket to return fd 3 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM,
+					   IPPROTO_TLS_1_2, 3);
 
 	/* Mock setsockopt calls (send timeout, sec_tag_list, peer_verify, poll callback) */
 	/* Note: SO_BINDTOPDN is not called when cid=0 */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 
 	/* Send AT command: family=1(IPv4), type=1(STREAM), role=0(client), sec_tag=42 */
 	send_at_command("AT#XSSOCKET=1,1,0,42\r\n");
@@ -2806,11 +2808,11 @@ void test_xssocket_ipv4_tcp_client(void)
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET:") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "3,1,258") !=
-			 NULL); /* handle=3, type=1(STREAM), proto=258(TLS) */
+			 NULL); /* handle=3, type=1(STREAM), proto=IPPROTO_TLS_1_2 */
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -2823,15 +2825,15 @@ void test_xssocket_ipv4_dtls_client(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 4 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM,
-					   273 /* NRF_SPROTO_DTLS1v2 */, 4);
+	/* Mock zsock_socket to return fd 4 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM,
+					   IPPROTO_DTLS_1_2, 4);
 
 	/* Mock setsockopt calls */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 
 	/* Send AT command: family=1(IPv4), type=2(DGRAM), role=0(client), sec_tag=16842752 */
 	send_at_command("AT#XSSOCKET=1,2,0,16842752\r\n");
@@ -2840,11 +2842,11 @@ void test_xssocket_ipv4_dtls_client(void)
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET:") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "4,2,273") !=
-			 NULL); /* handle=4, type=2(DGRAM), proto=273(DTLS) */
+			 NULL); /* handle=4, type=2(DGRAM), proto=IPPROTO_DTLS_1_2 */
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -2857,15 +2859,15 @@ void test_xssocket_ipv6_tcp_client(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 1 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM,
-					   258 /* NRF_SPROTO_TLS1v2 */, 1);
+	/* Mock zsock_socket to return fd 1 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET6, SOCK_STREAM,
+					   IPPROTO_TLS_1_2, 1);
 
 	/* Mock setsockopt calls */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
 
 	/* Send AT command: family=2(IPv6), type=1(STREAM), role=0(client), sec_tag=42 */
 	send_at_command("AT#XSSOCKET=2,1,0,42\r\n");
@@ -2874,11 +2876,11 @@ void test_xssocket_ipv6_tcp_client(void)
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET:") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "1,1,258") !=
-			 NULL); /* handle=1, type=1, proto=258(TLS) */
+			 NULL); /* handle=1, type=1, proto=IPPROTO_TLS_1_2 */
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -2891,9 +2893,9 @@ void test_xssocket_ipv4_tcp_server(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 0 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
-					   258 /* NRF_SPROTO_TLS1v2 */, 0);
+	/* Mock zsock_socket to return fd 0 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM,
+					   IPPROTO_TLS_1_2, 0);
 
 	/* Mock setsockopt calls in the expected order:
 	 * 1. SO_SNDTIMEO (SOL_SOCKET)
@@ -2901,10 +2903,10 @@ void test_xssocket_ipv4_tcp_server(void)
 	 * 3. SO_SEC_PEER_VERIFY (SOL_SECURE)
 	 * 4. SO_POLLCB (SOL_SOCKET)
 	 */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 
 	/* Send AT command: family=1(IPv4), type=1(STREAM), role=1(server), sec_tag=42 */
 	send_at_command("AT#XSSOCKET=1,1,1,42\r\n");
@@ -2913,11 +2915,11 @@ void test_xssocket_ipv4_tcp_server(void)
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET:") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "0,1,258") !=
-			 NULL); /* handle=0, type=1, proto=258(TLS) */
+			 NULL); /* handle=0, type=1, proto=IPPROTO_TLS_1_2 */
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -2930,15 +2932,15 @@ void test_xssocket_custom_peer_verify(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 3 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
-					   258 /* NRF_SPROTO_TLS1v2 */, 3);
+	/* Mock zsock_socket to return fd 3 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM,
+					   IPPROTO_TLS_1_2, 3);
 
 	/* Mock setsockopt calls */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 
 	/* Send AT command: family=1, type=1, role=0, sec_tag=42, peer_verify=0(none) */
 	send_at_command("AT#XSSOCKET=1,1,0,42,0\r\n");
@@ -2947,11 +2949,11 @@ void test_xssocket_custom_peer_verify(void)
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET:") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "3,1,258") !=
-			 NULL); /* handle=3, type=1, proto=258(TLS) */
+			 NULL); /* handle=3, type=1, proto=IPPROTO_TLS_1_2 */
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -2964,12 +2966,12 @@ void test_xssocket_with_pdn_cid(void)
 {
 	const char *response;
 
-	/* Mock nrf_socket to return fd 1 */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
-					   258 /* NRF_SPROTO_TLS1v2 */, 1);
+	/* Mock zsock_socket to return fd 1 */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM,
+					   IPPROTO_TLS_1_2, 1);
 
 	/* Mock setsockopt calls (SO_BINDTOPDN is called because cid=1, even though pdn_id=0) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
 
 	/* Mock AT%XGETPDNID command for PDN ID retrieval (cid=1 -> pdn_id=1) */
 	const char *pdn_id_resp = "%XGETPDNID: 1\r\nOK\r\n";
@@ -2980,10 +2982,10 @@ void test_xssocket_with_pdn_cid(void)
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_len(__LINE__);
 	__cmock_nrf_modem_at_cmd_CMockIgnoreArg_fmt(__LINE__);
 
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_BINDTOPDN */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_BINDTOPDN */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 
 	/* Send AT command: family=1, type=1, role=0, sec_tag=42, peer_verify=2, cid=1 */
 	send_at_command("AT#XSSOCKET=1,1,0,42,2,1\r\n");
@@ -2992,11 +2994,11 @@ void test_xssocket_with_pdn_cid(void)
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET:") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "1,1,258") !=
-			 NULL); /* handle=1, type=1, proto=258(TLS) */
+			 NULL); /* handle=1, type=1, proto=IPPROTO_TLS_1_2 */
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
 }
 
@@ -3031,28 +3033,28 @@ void test_xsocketopt_set_get(void)
 	const char *response;
 
 	/* Create a socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 4);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 4);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 4") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Set SO_RCVTIMEO (option 20) to 30 seconds */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKETOPT=4,1,20,30\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Set SO_SNDTIMEO (option 21) to 60 seconds */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKETOPT=4,1,21,60\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Get SO_RCVTIMEO (option 20) - should return 30 */
-	__cmock_nrf_getsockopt_Stub(mock_getsockopt_timeval_callback);
+	__cmock_zsock_getsockopt_Stub(mock_getsockopt_timeval_callback);
 	send_at_command("AT#XSOCKETOPT=4,0,20\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKETOPT: 4,30") != NULL);
@@ -3065,7 +3067,7 @@ void test_xsocketopt_set_get(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(4, 0);
+	__cmock_zsock_close_ExpectAndReturn(4, 0);
 	send_at_command("AT#XCLOSE=4\r\n");
 }
 
@@ -3079,22 +3081,22 @@ void test_xsocketopt_reuseaddr(void)
 	const char *response;
 
 	/* Create a socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 0") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Set SO_REUSEADDR (option 2) to enabled (1) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKETOPT=0,1,2,1\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -3109,29 +3111,29 @@ void test_xsocketopt_tcp_srv_sesstimeo(void)
 	const char *response;
 
 	/* Create a TCP socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 0") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Set SO_TCP_SRV_SESSTIMEO (option 55) to 135 */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKETOPT=0,1,55,135\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Get SO_TCP_SRV_SESSTIMEO (option 55) - should return 135 */
-	__cmock_nrf_getsockopt_Stub(mock_getsockopt_tcp_srv_sesstimeo_callback);
+	__cmock_zsock_getsockopt_Stub(mock_getsockopt_tcp_srv_sesstimeo_callback);
 	send_at_command("AT#XSOCKETOPT=0,0,55\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKETOPT: 0,135") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Set SO_TCP_SRV_SESSTIMEO (option 55) to 0 */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSOCKETOPT=0,1,55,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
@@ -3143,7 +3145,7 @@ void test_xsocketopt_tcp_srv_sesstimeo(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -3158,37 +3160,37 @@ void test_xssocketopt_set_get(void)
 	const char *response;
 
 	/* Create a secure socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
-					   258 /* NRF_SPROTO_TLS1v2 */, 0);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM,
+					   IPPROTO_TLS_1_2, 0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* Bind to PDN */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_TAG_LIST */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SEC_PEER_VERIFY */
 	send_at_command("AT#XSSOCKET=1,1,0,42\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKET: 0") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Set TLS_PEER_VERIFY (option 5) to optional (1) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSSOCKETOPT=0,1,5,1\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Set TLS_SESSION_CACHE (option 12) to enabled (1) */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSSOCKETOPT=0,1,12,1\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Set TLS_HOSTNAME (option 2) to "test.server.com" */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0);
 	send_at_command("AT#XSSOCKETOPT=0,1,2,\"test.server.com\"\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Get TLS_PEER_VERIFY (option 5) - should return 1 */
-	__cmock_nrf_getsockopt_Stub(mock_getsockopt_int_callback);
+	__cmock_zsock_getsockopt_Stub(mock_getsockopt_int_callback);
 	send_at_command("AT#XSSOCKETOPT=0,0,5\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKETOPT: 0,1") != NULL);
@@ -3201,14 +3203,14 @@ void test_xssocketopt_set_get(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Get TLS_HOSTNAME (option 2) - should return "test.server.com" */
-	__cmock_nrf_getsockopt_Stub(mock_getsockopt_hostname_callback);
+	__cmock_zsock_getsockopt_Stub(mock_getsockopt_hostname_callback);
 	send_at_command("AT#XSSOCKETOPT=0,0,2\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSSOCKETOPT: 0,test.server.com") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(0, 0);
+	__cmock_zsock_close_ExpectAndReturn(0, 0);
 	send_at_command("AT#XCLOSE=0\r\n");
 }
 
@@ -3263,16 +3265,16 @@ void test_xrecvcfg_read_command(void)
 	const char *response;
 
 	/* Create a socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 3);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 3);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 3") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Configure receive mode: socket 3, flags=1 (AT_MODE), hex_mode=0 */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB update for receive config */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB update for receive config */
 	send_at_command("AT#XRECVCFG=3,1,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
@@ -3284,7 +3286,7 @@ void test_xrecvcfg_read_command(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close socket */
-	__cmock_nrf_close_ExpectAndReturn(3, 0);
+	__cmock_zsock_close_ExpectAndReturn(3, 0);
 	send_at_command("AT#XCLOSE=3\r\n");
 }
 
@@ -3298,18 +3300,18 @@ void test_xrecvcfg_set_all_sockets(void)
 	const char *response;
 
 	/* Create first socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, NRF_IPPROTO_TCP, 1);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_STREAM, IPPROTO_TCP, 1);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,1,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 1") != NULL);
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Create second socket */
-	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_DGRAM, NRF_IPPROTO_UDP, 2);
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
+	__cmock_zsock_socket_ExpectAndReturn(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 2);
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_SNDTIMEO */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* SO_POLLCB */
 	send_at_command("AT#XSOCKET=1,2,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "#XSOCKET: 2") != NULL);
@@ -3317,8 +3319,8 @@ void test_xrecvcfg_set_all_sockets(void)
 
 	/* Configure receive mode for ALL sockets: flags=1 (AT_MODE), hex_mode=0 */
 	/* Omit handle parameter to apply to all sockets */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB update for socket 1 */
-	__cmock_nrf_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB update for socket 2 */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB update for socket 1 */
+	__cmock_zsock_setsockopt_ExpectAnyArgsAndReturn(0); /* POLLCB update for socket 2 */
 	send_at_command("AT#XRECVCFG=,1,0\r\n");
 	response = get_captured_response();
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
@@ -3331,9 +3333,9 @@ void test_xrecvcfg_set_all_sockets(void)
 	TEST_ASSERT_TRUE(strstr(response, "OK") != NULL);
 
 	/* Close sockets */
-	__cmock_nrf_close_ExpectAndReturn(1, 0);
+	__cmock_zsock_close_ExpectAndReturn(1, 0);
 	send_at_command("AT#XCLOSE=1\r\n");
-	__cmock_nrf_close_ExpectAndReturn(2, 0);
+	__cmock_zsock_close_ExpectAndReturn(2, 0);
 	send_at_command("AT#XCLOSE=2\r\n");
 }
 


### PR DESCRIPTION
Replace nrf_ socket operations with offloaded zsock_ socket operations.

Note: We changed from `zsock_socket` to `nrf_socket` in PR #47 due to `SO_POLLCB` support being only for nrf_sockets.. Now that we have `SO_POLLCB`, we can move back to offloaded sockets.

Jira: SM-319 
