### PR TITLE
app: Enable boot logging

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -17,8 +17,8 @@ CONFIG_EVENTFD=y
 # Enable UART logging by default.
 CONFIG_UART_CONSOLE=y
 CONFIG_LOG_BACKEND_UART=y
-# Logging does not start until activated via AT#XLOG=1 and is deactivated with AT#XLOG=0.
-CONFIG_LOG_BACKEND_UART_AUTOSTART=n
+# Logging starts automatically, but it is disabled after bootup.
+CONFIG_LOG_BACKEND_UART_AUTOSTART=y
 
 # Disable Segger RTT logging by default.
 CONFIG_USE_SEGGER_RTT=n

--- a/app/src/sm_log.c
+++ b/app/src/sm_log.c
@@ -133,23 +133,37 @@ STATIC int handle_at_log(enum at_parser_cmd_type cmd_type, struct at_parser *par
 	return -EINVAL;
 }
 
+/* Whether bootloader mode is enabled. */
+extern bool sm_bootloader_mode_enabled;
+
 static int sm_log_init(void)
 {
-	if (!IS_ENABLED(CONFIG_LOG_BACKEND_UART) ||
-	    !IS_ENABLED(CONFIG_LOG_BACKEND_UART_AUTOSTART)) {
-		/* Start with UART log backend disabled. */
-		if (uart_suspend()) {
-			LOG_ERR("Failed to suspend UART log backend");
-			sm_init_failed = true;
-			return -EFAULT;
-		}
-	} else {
+	if (sm_bootloader_mode_enabled) {
+		/* Keep the logging (and logging UART) enabled in bootloader mode */
 		log_active = true;
+		return 0;
+	}
+
+	const struct log_backend *log_be = log_backend_get_by_name("log_backend_uart");
+
+	if (log_be) {
+		LOG_DBG("Use AT#XLOG=1 to enable UART logging");
+		sm_log_flush();
+		log_backend_disable(log_be);
+	}
+
+	/* Suspend the UART device that is shared by application log and modem trace */
+	int ret = uart_suspend();
+
+	if (ret) {
+		urc_send(SM_SYNC_ERR_STR);
+		return ret;
 	}
 
 	return 0;
 }
 
-SYS_INIT(sm_log_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
+/* Runs after application initialization */
+SYS_INIT(sm_log_init, APPLICATION, 101);
 
 #endif /* DT_HAS_CHOSEN(zephyr_console) */

--- a/app/src/sm_trace_backend_uart.c
+++ b/app/src/sm_trace_backend_uart.c
@@ -271,20 +271,3 @@ STATIC int handle_at_trace(enum at_parser_cmd_type cmd_type, struct at_parser *p
 
 	return -EINVAL;
 }
-
-static int sm_trace_backend_uart_init(void)
-{
-	/* Allow UART to be active if CONFIG_LOG_BACKEND_UART_AUTOSTART=y */
-	if (!IS_ENABLED(CONFIG_LOG_BACKEND_UART_AUTOSTART)) {
-		/* Start the trace backend disabled. */
-		if (uart_suspend()) {
-			LOG_ERR("Failed to suspend UART trace backend");
-			sm_init_failed = true;
-			return -EFAULT;
-		}
-	}
-
-	return 0;
-}
-
-SYS_INIT(sm_trace_backend_uart_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/app/sysbuild/b0/boards/nrf9151dk_nrf9151.overlay
+++ b/app/sysbuild/b0/boards/nrf9151dk_nrf9151.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart1;
+	};
+};
+
+&uart1 {
+	current-speed = <1000000>;
+	status = "okay";
+};

--- a/app/sysbuild/b0/prj.conf
+++ b/app/sysbuild/b0/prj.conf
@@ -29,9 +29,3 @@ CONFIG_ASSERT=n
 
 # Avoid triggering IRQs from the RTC
 CONFIG_NRF_RTC_TIMER=n
-
-# Serial Modem specific changes:
-# Disable logging so that Ready-message is the first one in startup.
-CONFIG_LOG=n
-CONFIG_CONSOLE=n
-CONFIG_UART_CONSOLE=n

--- a/app/sysbuild/mcuboot/boards/nrf9151dk_nrf9151.overlay
+++ b/app/sysbuild/mcuboot/boards/nrf9151dk_nrf9151.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart1;
+	};
+};
+
+&uart1 {
+	current-speed = <1000000>;
+	status = "okay";
+};

--- a/app/sysbuild/mcuboot/prj.conf
+++ b/app/sysbuild/mcuboot/prj.conf
@@ -26,21 +26,17 @@ CONFIG_FPROTECT=y
 
 CONFIG_LOG=y
 CONFIG_LOG_MODE_MINIMAL=y
-### Ensure Zephyr logging changes don't use more resources
-CONFIG_LOG_DEFAULT_LEVEL=0
-### Use info log level by default
 CONFIG_MCUBOOT_LOG_LEVEL_INF=y
 ### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
 CONFIG_CBPRINTF_NANO=y
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=0
 
 ### Serial Modem
-# Do not use UART, for power saving
+# Enable mcuboot traces
 CONFIG_CONSOLE=y
 CONFIG_MCUBOOT_SERIAL=n
 CONFIG_BOOT_SERIAL_UART=n
-CONFIG_UART_CONSOLE=n
-CONFIG_LOG_BACKEND_UART=n
+CONFIG_UART_CONSOLE=y
 CONFIG_CONSOLE_HANDLER=n
 
 # Enable software downgrade prevention for the application.

--- a/doc/app/at_trace.rst
+++ b/doc/app/at_trace.rst
@@ -19,7 +19,8 @@ See :ref:`sm_logging_uart_backend` for a full description of the feature.
 
 The Zephyr application log backend (``AT#XLOG``) and the modem trace backend (``AT#XTRACE``) share a single UART.
 They are mutually exclusive: enabling one while the other is active returns an error.
-The trace UART is suspended when neither backend is active and resumed automatically when either backend is enabled.
+During boot, the UART outputs logs from B0, MCUboot, and the application.
+After initialization, the UART is suspended when no backend is active and resumed when at least one backend is enabled.
 
 The trace UART is configured at 1000000 baud rate to support the high data rate required for the modem traces.
 Trace data is available through the UART1 interface (VCOM1 on the nRF9151 DK).

--- a/doc/app/sm_logging.rst
+++ b/doc/app/sm_logging.rst
@@ -13,9 +13,10 @@ Logs often refer to the |SM| application logging while the modem logs are referr
 Application logging
 *******************
 
-|SM| outputs application logs over ``UART1`` (VCOM1 on the nRF9151 DK) by default.
-The UART is kept suspended at startup and activated at runtime using the ``AT#XLOG=1`` command.
-This avoids any UART power overhead when logs are not needed.
+|SM| outputs B0, MCUboot, and application logs over ``UART1`` (VCOM1 on the nRF9151 DK) during boot.
+After the application is initialized, the log backend is disabled, and the UART is suspended.
+Use ``AT#XLOG=1`` to enable application logs and resume the UART.
+This avoids UART power overhead when logs are not needed during normal operation.
 See :ref:`SM_AT_trace` for the full command reference.
 
 .. note::
@@ -83,7 +84,7 @@ To also enable the modem trace backend (``AT#XTRACE``), build with the Kconfig o
 
    west build -p -b nrf9151dk/nrf9151/ns -- -DEXTRA_CONF_FILE="overlay-trace-backend-uart.conf"
 
-After flashing, the UART is suspended at startup.
+After the application is initialized, the UART is suspended.
 Use ``AT#XLOG=1`` to activate application logs and ``AT#XTRACE=1`` to activate modem traces.
 See :ref:`SM_AT_trace` for the full command reference.
 


### PR DESCRIPTION
B0, MCUboot and application log from the boot.

The logging is disabled after the application is initialized, so that the application can enter low-power states.

Logging can be re-enabled with AT#XLOG=1, which also enables the logging UART.

Jira: SM-282
Jira: SM-333
