### PR TITLE
app: http: Add hex_format option to AT#XHTTPCREQ

### DIFF
--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -20,7 +20,7 @@
 
 LOG_MODULE_REGISTER(sm_httpc, CONFIG_SM_LOG_LEVEL);
 
-#define HTTP_RECV_BUF_SIZE        2048
+#define HTTP_RECV_BUF_SIZE        2049 /* 2048 bytes + null terminator for string ops */
 #define HTTP_URL_MAX_LEN          512
 #define HTTP_HOST_MAX_LEN         256
 #define HTTP_PATH_MAX_LEN         256
@@ -82,6 +82,7 @@ struct http_request {
 	int64_t timeout_timestamp;  /* Idle timeout deadline; reset on each send/receive */
 	struct modem_pipe *pipe;    /* AT pipe that created this request */
 	bool manual_mode;           /* Manual mode: body not auto-received, host pulls chunks */
+	bool hex_rx;                /* Deliver response body as ASCII hex string */
 	int bytes_sent;             /* Response-body bytes sent to the host */
 	bool connection_close;      /* Server sent "Connection: close" header */
 };
@@ -481,7 +482,22 @@ static void http_send_headers_complete(struct http_request *req)
 		 req->content_length);
 }
 
-/* Send data URC followed by raw bytes */
+static void http_data_send_hex(struct modem_pipe *pipe, const uint8_t *buf, size_t len)
+{
+	char hex_buf[257];
+	size_t chunk = (sizeof(hex_buf) - 1) / 2;
+	size_t done = 0;
+
+	while (done < len) {
+		size_t n = MIN(chunk, len - done);
+		size_t sz = bin2hex(buf + done, n, hex_buf, sizeof(hex_buf));
+
+		data_send(pipe, hex_buf, sz);
+		done += n;
+	}
+}
+
+/* Send data URC followed by raw bytes or hex string */
 static void http_send_data(struct http_request *req, const uint8_t *data, int len)
 {
 	if (len <= 0) {
@@ -490,7 +506,11 @@ static void http_send_data(struct http_request *req, const uint8_t *data, int le
 
 	urc_send_to(req->pipe, "\r\n#XHTTPCDATA: %d,%d,%d\r\n", req->fd, req->bytes_sent, len);
 	req->bytes_sent += len;
-	data_send(req->pipe, data, len);
+	if (req->hex_rx) {
+		http_data_send_hex(req->pipe, data, (size_t)len);
+	} else {
+		data_send(req->pipe, data, len);
+	}
 }
 
 /*
@@ -1049,7 +1069,10 @@ static int http_datamode_callback(uint8_t op, const uint8_t *data, int len, uint
 	return 0;
 }
 
-/* AT#XHTTPCREQ - Start an HTTP/HTTPS request (async) */
+/**
+ * Start an asynchronous HTTP or HTTPS request on a connected AT socket.
+ * Returns OK immediately; headers arrive as #XHTTPCHEAD and body as #XHTTPCDATA/#XHTTPCSTAT.
+ */
 SM_AT_CMD_CUSTOM(xhttpcreq, "AT#XHTTPCREQ", handle_at_httpcreq);
 STATIC int handle_at_httpcreq(enum at_parser_cmd_type cmd_type, struct at_parser *parser,
 			      uint32_t param_count)
@@ -1124,7 +1147,6 @@ STATIC int handle_at_httpcreq(enum at_parser_cmd_type cmd_type, struct at_parser
 			return -EINVAL;
 		}
 
-		int body_len = 0;
 		int next_param_idx = 4; /* Next parameter index after method */
 
 		/* Parse optional <auto_reception> flag */
@@ -1141,22 +1163,34 @@ STATIC int handle_at_httpcreq(enum at_parser_cmd_type cmd_type, struct at_parser
 			/* If parse fails (string param), leave next_param_idx unchanged. */
 		}
 
+		/* Parse optional <format> flag */
+		int format = 0; /* default: binary */
+
+		if (param_count > next_param_idx) {
+			if (at_parser_num_get(parser, next_param_idx, &format) == 0) {
+				if (format != 0 && format != 1) {
+					http_close_request(req);
+					return -EINVAL;
+				}
+				next_param_idx++;
+			}
+		}
+
 		/* Parse optional body length (data mode for POST/PUT).
 		 * The parameter slot is always consumed when an integer is present
 		 * so that extra headers start at a consistent index regardless of method.
 		 */
-		if (param_count > next_param_idx) {
-			int tmp = 0;
+		int body_len = 0;
 
-			if (at_parser_num_get(parser, next_param_idx, &tmp) == 0) {
+		if (param_count > next_param_idx) {
+			if (at_parser_num_get(parser, next_param_idx, &body_len) == 0) {
 				if (method == HTTP_POST || method == HTTP_PUT) {
-					body_len = tmp;
 					if (body_len < 0) {
 						LOG_ERR("Invalid body_len: %d", body_len);
 						http_close_request(req);
 						return -EINVAL;
 					}
-				} else if (tmp != 0) {
+				} else if (body_len != 0) {
 					LOG_ERR("body_len must be 0 for method %d", method);
 					http_close_request(req);
 					return -EINVAL;
@@ -1227,6 +1261,8 @@ STATIC int handle_at_httpcreq(enum at_parser_cmd_type cmd_type, struct at_parser
 			LOG_INF("HTTP %d: Manual mode enabled", req->fd);
 		}
 
+		req->hex_rx = (bool)format;
+
 		/* Parse URL */
 		err = http_parse_url_components(url, url_len, req);
 		if (err) {
@@ -1276,7 +1312,7 @@ STATIC int handle_at_httpcreq(enum at_parser_cmd_type cmd_type, struct at_parser
 
 	case AT_PARSER_CMD_TYPE_TEST:
 		rsp_send("\r\n#XHTTPCREQ: <handle>,<url>,<method>"
-			 "[,<auto_reception>[,<body_len>[,<header>]...]]\r\n");
+			 "[,<auto_reception>[,<format>[,<body_len>[,<header>]...]]]\r\n");
 
 		err = 0;
 		break;
@@ -1330,7 +1366,11 @@ static int pull_data(int socket_fd, int pull_len)
 		req->timeout_timestamp = k_uptime_get() + HTTP_RESPONSE_TIMEOUT_MS;
 		rsp_send("\r\n#XHTTPCDATA: %d,%d,%d\r\n", req->fd, req->bytes_sent, send_len);
 		req->bytes_sent += send_len;
-		data_send(req->pipe, req->recv_buf, send_len);
+		if (req->hex_rx) {
+			http_data_send_hex(req->pipe, req->recv_buf, (size_t)send_len);
+		} else {
+			data_send(req->pipe, req->recv_buf, send_len);
+		}
 		req->recv_buf_len -= send_len;
 		if (req->recv_buf_len > 0) {
 			memmove(req->recv_buf, req->recv_buf + send_len, req->recv_buf_len);
@@ -1366,7 +1406,11 @@ static int pull_data(int socket_fd, int pull_len)
 	req->timeout_timestamp = k_uptime_get() + HTTP_RESPONSE_TIMEOUT_MS;
 	rsp_send("\r\n#XHTTPCDATA: %d,%d,%d\r\n", req->fd, req->bytes_sent, ret);
 	req->bytes_sent += ret;
-	data_send(req->pipe, req->recv_buf, ret);
+	if (req->hex_rx) {
+		http_data_send_hex(req->pipe, req->recv_buf, (size_t)ret);
+	} else {
+		data_send(req->pipe, req->recv_buf, ret);
+	}
 	last_sent = ret;
 
 check_complete:

--- a/doc/app/at_httpc.rst
+++ b/doc/app/at_httpc.rst
@@ -35,7 +35,7 @@ Syntax
 
 ::
 
-   AT#XHTTPCREQ=<handle>,<url>,<method>[,<auto_reception>[,<body_len>[,<header 1>[,<header 2>[...]]]]]
+   AT#XHTTPCREQ=<handle>,<url>,<method>[,<auto_reception>[,<format>[,<body_len>[,<header 1>[,<header 2>[...]]]]]]
 
 * The ``<handle>`` parameter is an integer.
   It identifies the connected socket handle returned by ``AT#XSOCKET`` or ``AT#XSSOCKET``, and connected by ``AT#XCONNECT``.
@@ -60,6 +60,19 @@ Syntax
   * ``0`` - Manual mode.
     Response body reception is paused after the headers are parsed and ``#XHTTPCHEAD`` is emitted.
     The host must then retrieve body data in chunks using ``AT#XHTTPCDATA`` commands.
+
+* The ``<format>`` parameter is an optional integer.
+  It controls the encoding used to deliver response body bytes to the host.
+  It can accept the following values:
+
+  * ``0`` - Binary (default).
+    Response body bytes are forwarded to the host as raw binary.
+  * ``1`` - Hex string.
+    Response body bytes are encoded as a lower-case ASCII hex string before delivery.
+    Each raw byte becomes two hex characters.
+    The ``<length>`` field in ``#XHTTPCDATA`` always reports the raw byte count.
+    The actual data delivered is ``2×<length>`` ASCII hex characters.
+    Applies to both automatic and manual reception modes.
 
 * The ``<body_len>`` parameter is an optional integer.
   It is required as a placeholder when ``<header>`` parameters follow.
@@ -115,7 +128,9 @@ Unsolicited notification
 
    #XHTTPCDATA: <handle>,<offset>,<length>
 
-The notification line is terminated with ``\r\n`` and the raw body bytes follow immediately with no additional separator.
+The notification line is terminated with ``\r\n``.
+In binary mode (``<format>=0``, default), the raw body bytes follow immediately with no additional separator.
+In hex mode (``<format>=1``), ``2×<length>`` lower-case ASCII hex characters follow instead of raw bytes.
 
 * The ``<handle>`` parameter is an integer.
   It identifies the socket.
@@ -192,11 +207,26 @@ HTTP GET (manual mode):
 
    #XHTTPCSTAT: 0,200,261,0
 
+HTTP GET with hex-encoded response body (``format=1``, automatic mode):
+
+::
+
+   AT#XHTTPCREQ=0,<url>,0,1,1
+   #XHTTPCREQ: 0
+   OK
+
+   #XHTTPCHEAD: 0,200,12
+
+   #XHTTPCDATA: 0,0,12
+   48656c6c6f20576f726c6421
+
+   #XHTTPCSTAT: 0,200,12,0
+
 HTTP POST with JSON body and custom header:
 
 ::
 
-   AT#XHTTPCREQ=0,<url>,1,1,15,"Content-Type: application/json"
+   AT#XHTTPCREQ=0,<url>,1,1,0,15,"Content-Type: application/json"
    #XHTTPCREQ: 0
    OK
    {"key":"value"}
@@ -209,13 +239,13 @@ HTTP POST with JSON body and custom header:
 
    #XHTTPCSTAT: 0,200,432,0
 
-HTTP GET with Range header (``body_len=0`` is required as a placeholder when headers follow a GET):
+HTTP GET data in binary format with Range header (``body_len=0`` is required as a placeholder when ``<header>`` parameters follow):
 
 In this example the server returns ``connection_close=1``, so the host must close and reopen the socket before the next request.
 
 ::
 
-   AT#XHTTPCREQ=0,<url>,0,1,0,"Range: bytes=0-127"
+   AT#XHTTPCREQ=0,<url>,0,1,0,0,"Range: bytes=0-127"
    #XHTTPCREQ: 0
    OK
 
@@ -226,7 +256,7 @@ In this example the server returns ``connection_close=1``, so the host must clos
 
    #XHTTPCSTAT: 0,206,128,0
 
-   AT#XHTTPCREQ=0,<url>,0,1,0,"Range: bytes=128-255"
+   AT#XHTTPCREQ=0,<url>,0,1,0,0,"Range: bytes=128-255"
    #XHTTPCREQ: 0
    OK
 
@@ -257,7 +287,7 @@ HTTP POST with chunked response (``content_length=-1``):
 
 ::
 
-   AT#XHTTPCREQ=0,<url>,1,1,1024
+   AT#XHTTPCREQ=0,<url>,1,1,0,1024
    #XHTTPCREQ: 0
    OK
    <1024 bytes payload>
@@ -292,7 +322,7 @@ Response syntax
 
 ::
 
-   #XHTTPCREQ: <handle>,<url>,<method>[,<auto_reception>[,<body_len>[,<header>]...]]
+   #XHTTPCREQ: <handle>,<url>,<method>[,<auto_reception>[,<format>[,<body_len>[,<header>]...]]]
 
 Example
 ~~~~~~~
@@ -300,7 +330,7 @@ Example
 ::
 
    AT#XHTTPCREQ=?
-   #XHTTPCREQ: <handle>,<url>,<method>[,<auto_reception>[,<body_len>[,<header>]...]]
+   #XHTTPCREQ: <handle>,<url>,<method>[,<auto_reception>[,<format>[,<body_len>[,<header>]...]]]
    OK
 
 HTTP data pull #XHTTPCDATA


### PR DESCRIPTION
Add an optional hex_format parameter (5th positional argument) to AT#XHTTPCREQ. When set to 1, the response body delivered in AT#XHTTPCDATA URCs is encoded as an ASCII hex string (two chars per byte) instead of raw binary bytes.

Jira: SM-337