### PR TITLE
app: coapc: Fix socket collision with nRF Cloud and provisioning

### DIFF
--- a/app/src/sm_at_coap.c
+++ b/app/src/sm_at_coap.c
@@ -134,6 +134,8 @@ static void coap_close_request(struct coap_request *req)
 		coap_pending_req = NULL;
 	}
 
+	sm_coap_client.fd = -1;
+
 	free(req->staging);
 	free(req->rx_buf);
 	free(req);
@@ -946,6 +948,7 @@ STATIC int handle_at_coap_data(enum at_parser_cmd_type cmd_type, struct at_parse
 
 static int sm_at_coap_init(void)
 {
+	sm_coap_client.fd = -1;
 	return coap_client_init(&sm_coap_client, "sm_coap");
 }
 


### PR DESCRIPTION
sm_coap_client is zero-initialized, so fd=0. Since Zephyr's ZVFS allocates FDs from index 0, the first socket opened by nRF Cloud or provisioning also gets FD 0. coap_client's get_client() then finds sm_coap_client first in the registered clients array and misroutes responses to it.

Initialize sm_coap_client.fd=-1 at init and reset it to -1 in coap_close_request(), matching the pattern used by the nRF Cloud and provisioning CoAP transports.