### PR TITLE
app: coap,  http: Add CRLF after data in auto receive mode

### DIFF
--- a/app/src/sm_at_coap.c
+++ b/app/src/sm_at_coap.c
@@ -168,7 +168,11 @@ static void coap_send_data(struct coap_request *req, const uint8_t *payload, siz
 		return;
 	}
 
-	urc_send_to(req->pipe, "\r\n#XCOAPCDATA: %d,%d,%d\r\n", req->fd,
+	/* Lock the AT host to prevent URCs from being injected between the notification
+	 * header, the data bytes, and the trailing CRLF.
+	 */
+	sm_at_host_lock(req->pipe);
+	rsp_send_to(req->pipe, "\r\n#XCOAPCDATA: %d,%d,%d\r\n", req->fd,
 		    (int)req->bytes_sent, (int)payload_len);
 	req->bytes_sent += payload_len;
 	if (req->hex_rx) {
@@ -178,6 +182,7 @@ static void coap_send_data(struct coap_request *req, const uint8_t *payload, siz
 	}
 	/* CRLF after the data chunk, consistent with socket auto-receive behaviour. */
 	rsp_send_to(req->pipe, "\r\n");
+	sm_at_host_unlock(req->pipe);
 }
 
 /* Notify host that a response block is ready to pull in manual receive mode. */

--- a/app/src/sm_at_coap.c
+++ b/app/src/sm_at_coap.c
@@ -176,6 +176,8 @@ static void coap_send_data(struct coap_request *req, const uint8_t *payload, siz
 	} else {
 		data_send(req->pipe, payload, payload_len);
 	}
+	/* CRLF after the data chunk, consistent with socket auto-receive behaviour. */
+	rsp_send_to(req->pipe, "\r\n");
 }
 
 /* Notify host that a response block is ready to pull in manual receive mode. */

--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -511,6 +511,8 @@ static void http_send_data(struct http_request *req, const uint8_t *data, int le
 	} else {
 		data_send(req->pipe, data, len);
 	}
+	/* CRLF after the data chunk, consistent with socket auto-receive behaviour. */
+	rsp_send_to(req->pipe, "\r\n");
 }
 
 /*

--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -504,7 +504,11 @@ static void http_send_data(struct http_request *req, const uint8_t *data, int le
 		return;
 	}
 
-	urc_send_to(req->pipe, "\r\n#XHTTPCDATA: %d,%d,%d\r\n", req->fd, req->bytes_sent, len);
+	/* Lock the AT host to prevent URCs from being injected between the notification
+	 * header, the data bytes, and the trailing CRLF.
+	 */
+	sm_at_host_lock(req->pipe);
+	rsp_send_to(req->pipe, "\r\n#XHTTPCDATA: %d,%d,%d\r\n", req->fd, req->bytes_sent, len);
 	req->bytes_sent += len;
 	if (req->hex_rx) {
 		http_data_send_hex(req->pipe, data, (size_t)len);
@@ -513,6 +517,7 @@ static void http_send_data(struct http_request *req, const uint8_t *data, int le
 	}
 	/* CRLF after the data chunk, consistent with socket auto-receive behaviour. */
 	rsp_send_to(req->pipe, "\r\n");
+	sm_at_host_unlock(req->pipe);
 }
 
 /*

--- a/doc/app/at_coap.rst
+++ b/doc/app/at_coap.rst
@@ -146,7 +146,7 @@ Unsolicited notification
 
    #XCOAPCDATA: <handle>,<offset>,<length>
 
-The notification line is terminated with ``\r\n`` and the response data follows immediately with no additional separator.
+The notification line is terminated with ``\r\n``, the response data follows immediately, and a ``\r\n`` terminator follows the data bytes.
 In binary mode (default), the data is ``<length>`` raw bytes.
 In hex mode (``<format>=1``), the data is ``2×<length>`` lower-case ASCII hex characters.
 
@@ -221,6 +221,10 @@ CoAP GET (automatic mode, binary):
    AT#XCLOSE=0
    OK
 
+.. note::
+
+   In automatic mode, a ``\r\n`` terminator is appended after the data bytes of each ``#XCOAPCDATA`` notification.
+
 CoAP GET (automatic mode, hex-encoded response, ``format=1``):
 
 ::
@@ -232,6 +236,10 @@ CoAP GET (automatic mode, hex-encoded response, ``format=1``):
    32332e352043656c73697573
 
    #XCOAPCSTAT: 0,69,12
+
+.. note::
+
+   The hex string and the line break after it represent the ``2×<length>`` hex characters followed by the ``\r\n`` terminator.
 
 CoAP GET (manual mode):
 

--- a/doc/app/at_httpc.rst
+++ b/doc/app/at_httpc.rst
@@ -127,10 +127,11 @@ Unsolicited notification
 ``#XHTTPCDATA`` is emitted in automatic mode for each received body chunk::
 
    #XHTTPCDATA: <handle>,<offset>,<length>
+   <data>
 
-The notification line is terminated with ``\r\n``.
-In binary mode (``<format>=0``, default), the raw body bytes follow immediately with no additional separator.
-In hex mode (``<format>=1``), ``2×<length>`` lower-case ASCII hex characters follow instead of raw bytes.
+The notification line is terminated with ``\r\n``, the response data follows immediately, and a ``\r\n`` terminator follows the data bytes.
+In binary mode (``<format>=0``, default),  the data is ``<length>`` raw bytes.
+In hex mode (``<format>=1``), the data is ``2×<length>`` lower-case ASCII hex characters.
 
 * The ``<handle>`` parameter is an integer.
   It identifies the socket.
@@ -190,6 +191,10 @@ HTTP GET (automatic mode):
 
    #XHTTPCSTAT: 0,200,261,0
 
+.. note::
+
+   In automatic mode, a ``\r\n`` terminator is appended after the data bytes of each ``#XHTTPCDATA`` notification.
+
 HTTP GET (manual mode):
 
 ::
@@ -221,6 +226,8 @@ HTTP GET with hex-encoded response body (``format=1``, automatic mode):
    48656c6c6f20576f726c6421
 
    #XHTTPCSTAT: 0,200,12,0
+
+The hex string and the line break after it represent the ``2×<length>`` hex characters followed by the ``\r\n`` terminator.
 
 HTTP POST with JSON body and custom header:
 


### PR DESCRIPTION
Aligns with the behavior of #XRECVFROM and #XRECV.

Prevent URC interleaving in multi-part responses.