### PR TITLE
doc: Document Zephyr user pipes for AT command access

### DIFF
--- a/doc/app/sm_cellular_modem.rst
+++ b/doc/app/sm_cellular_modem.rst
@@ -203,10 +203,54 @@ The controlling chip runs a Zephyr application, which uses Zephyr's native IP st
      See :ref:`uart_configuration` for more information.
    * System mode is not configured. See the `%XSYSTEMMODE`_ command in the AT command Reference Guide for more details.
 
+User pipes for AT commands
+==========================
+
+Zephyr's cellular modem driver provides **user pipes** for sending AT commands to the modem while PPP is active.
+User pipes are additional CMUX channels (DLC channels 3 and 4) that the host application can use for modem configuration, DFU/FOTA, or other AT command operations.
+
+User pipe availability
+----------------------
+
+User pipes are available only when the modem driver has all CMUX channels open.
+This occurs after the following conditions are met:
+
+* CMUX has been started with ``AT+CMUX=0``.
+* The network interface is activated with ``net_if_up()``, which opens the CMUX channels, connects to the network, and establishes the PPP connection.
+
+When the network interface is deactivated with ``net_if_down()``, the PPP connection is closed and user pipes become unavailable.
+
+.. important::
+
+   User pipes are not available when PPP is closed.
+   The modem driver is designed so that ``net_if_up()`` opens all CMUX channels, including user pipes, and ``net_if_down()`` closes them.
+
+The DLC channel callback notifies the host application when a user pipe opens or closes.
+
+Use cases for user pipes
+------------------------
+
+User pipes allow the host application to send AT commands while maintaining an active PPP connection.
+Common use cases include:
+
+* Configuring eDRX and PSM settings (``AT+CEDRXS``, ``AT+CPSMS``).
+* Performing modem firmware updates using ``AT#XFOTA`` or DFU commands.
+* Querying modem status and diagnostics.
+* Managing SMS or other modem features not exposed through the PPP interface.
+* Temporarily pausing PPP for maintenance operations.
+
+.. note::
+
+   When using the ``nordic,nrf91-sm-v2`` cellular driver, you can temporarily pause the PPP connection by issuing ``AT+CFUN=4`` on a user pipe.
+   This command puts the modem into flight mode, which causes the cellular modem driver to wait for a network registration URC message.
+   The PPP connection remains paused until you restore normal operation with ``AT+CFUN=1``, at which point the modem re-registers with the network and the PPP connection resumes.
+   This is useful for performing maintenance operations that require the modem to be offline temporarily.
+
 Example
 =======
 
 The Zephyr modem driver sends ``AT+CMUX=0`` to start the CMUX, then uses DLC channel 1 for AT commands and DLC channel 2 for PPP.
+User pipes on DLC channels 3 and 4 become available for host application AT commands once the network interface is up.
 The dial script issues ``AT+CGDATA`` on DLC channel 2, which starts PPP on that channel and leaves DLC channel 1 free for AT commands and URCs.
 
 .. figure:: ../images/ppp-zephyr-sequence.svg

--- a/doc/samples/sm_ppp_shell.rst
+++ b/doc/samples/sm_ppp_shell.rst
@@ -96,10 +96,10 @@ The sample provides:
 * Network performance testing using zperf.
 * DNS resolution support.
 * Automatic modem connection management.
-* CMUX (GSM 07.10) multiplexing support.
+* CMUX (GSM 07.10) multiplexing support with user pipes for AT command access.
 * Power management with runtime power saving.
 
-For more information about using the nRF91 Series SiP as a Zephyr-compatible modem, see :ref:`sm_cellular_modem`.
+For more information about using the nRF91 Series SiP as a Zephyr-compatible modem, including how to use user pipes for AT commands alongside PPP, see :ref:`sm_cellular_modem`.
 
 Configuration
 *************
@@ -121,6 +121,7 @@ The CMUX configuration enables:
 * Power save mode that closes CMUX pipes when idle
 * 5 second idle timeout before entering power save
 * MTU size of 127 bytes for optimal performance
+* User pipes on DLC channels 3 and 4 for AT command access (available when the network interface is up)
 
 Building and running
 ********************
@@ -221,6 +222,47 @@ To run a UDP upload test:
 
 See the `zperf: Network Traffic Generator`_ for more details on using zperf.
 
+Send AT commands through user pipes
+===================================
+
+When the network interface is up, you can access the modem's AT command interface through the user pipes on CMUX DLC channels 3 and 4.
+By default, the shell sample is configured to use the user pipe on DLC channel 3.
+
+To send an AT command:
+
+.. code-block:: console
+
+   uart:~$ modem at AT+CFUN=4
+   EVENT: L3 [1] IPv4 address del 100.92.136.41
+   EVENT: L4 [1] disconnected
+   EVENT: L4 [1] IPv4 connectivity lost
+   EVENT: L2 [1] interface down
+   OK
+   [00:14:52.706,554] <dbg> modem_cellular: modem_cellular_log_state_changed: switch from registered to await PPP dead
+   [00:14:52.706,738] <dbg> modem_cellular: modem_cellular_log_event: event ppp dead
+   [00:14:53.095,303] <dbg> modem_cellular: modem_cellular_log_event: event deregistered
+   [00:14:54.706,661] <dbg> modem_cellular: modem_cellular_log_event: event timeout
+   [00:14:54.706,720] <dbg> modem_cellular: modem_cellular_log_state_changed: switch from await PPP dead to await registered
+   [00:14:56.706,792] <dbg> modem_cellular: modem_cellular_log_event: event timeout
+   uart:~$ modem at AT+CFUN?
+   +CFUN: 4
+   OK
+   uart:~$ modem at AT+CFUN=1
+   OK
+   [00:15:16.308,209] <dbg> modem_cellular: modem_cellular_log_event: event deregistered
+   EVENT: L2 [1] interface up
+   [00:15:18.072,762] <dbg> modem_cellular: modem_cellular_log_event: event registered
+   [00:15:18.072,803] <dbg> modem_cellular: modem_cellular_log_state_changed: switch from await registered to run dial script
+   [00:15:18.072,861] <dbg> modem_cellular: modem_cellular_log_event: event timeout
+   [00:15:18.100,659] <dbg> modem_cellular: modem_cellular_log_event: event script success
+   [00:15:18.100,740] <dbg> modem_cellular: modem_cellular_log_state_changed: switch from run dial script to registered
+   EVENT: L3 [1] IPv6 address add fe80::3330:3539:3831:3936
+   EVENT: L3 [1] IPv6 neighbor add fe80::5eff:fe00:533a
+   EVENT: L3 [1] IPv4 address add 100.92.136.41
+   EVENT: L4 [1] connected
+   EVENT: L4 [1] IPv4 connectivity available
+   uart:~$
+
 Shutting down the network interface
 ===================================
 
@@ -241,6 +283,7 @@ The sample enables the following key features:
 * Network shell (``CONFIG_NET_SHELL``)
 * Zperf (``CONFIG_NET_ZPERF``)
 * Power management (``CONFIG_PM_DEVICE``)
+* AT command shell (``CONFIG_MODEM_AT_SHELL``)
 
 References
 **********


### PR DESCRIPTION
Add comprehensive documentation for Zephyr cellular modem driver user pipes, which provide AT command access alongside PPP connections.

## Changes
- Document user pipe concept and availability in sm_cellular_modem.rst
- Explain that user pipes (DLC channels 3 and 4) are only available when all CMUX channels are open and PPP is active
- Add use cases: eDRX/PSM config, FOTA/DFU, diagnostics, SMS
- Document AT+CFUN=4 for temporarily pausing PPP via user pipe
- Update sm_ppp_shell sample docs to reference user pipes
- Add note about user pipe availability in sample configuration

User pipes are a key feature of the nordic,nrf91-sm-v2 driver that enables modem control and maintenance operations while maintaining an active PPP connection.

## Related Work
- Implementation: #250

Jira: SM-311