### PR TITLE
app: http: Cancel active request on AT#XCLOSE

### DIFF
--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -956,6 +956,20 @@ bool sm_at_httpc_poll_event(int fd, uint8_t events)
 	return (req && req->need_rearm_pollin);
 }
 
+void sm_at_httpc_socket_closed(int fd)
+{
+	k_mutex_lock(&http_mutex, K_FOREVER);
+	struct http_request *req = find_request(fd);
+
+	if (req) {
+		LOG_WRN("HTTP %d: socket closed with active request (state=%d); cleaning up",
+			fd, req->state);
+		http_send_cancel_status(req);
+		http_close_request(req);
+	}
+	k_mutex_unlock(&http_mutex);
+}
+
 /* Build HTTP request headers and send them synchronously for streaming POST/PUT */
 static int http_send_request_headers(struct http_request *req)
 {

--- a/app/src/sm_at_httpc.h
+++ b/app/src/sm_at_httpc.h
@@ -25,6 +25,17 @@
  */
 bool sm_at_httpc_poll_event(int fd, uint8_t events);
 
+/**
+ * @brief Notify HTTP client that a socket has been closed (e.g. via AT#XCLOSE).
+ *
+ * If a request is active on @p fd, it is cancelled: a cancel status URC
+ * (#XHTTPCSTAT with -1 status) is sent to the host and the request is freed.
+ * No-op if no request is active on @p fd.
+ *
+ * @param fd Socket file descriptor that was closed.
+ */
+void sm_at_httpc_socket_closed(int fd);
+
 /** @} */
 
 #endif /* SM_AT_HTTPC_H_ */

--- a/app/src/sm_at_socket.c
+++ b/app/src/sm_at_socket.c
@@ -715,6 +715,9 @@ static int do_socket_close(struct sm_socket *sock)
 
 	rsp_send("\r\n#XCLOSE: %d,%d\r\n", sock->fd, ret);
 
+#if defined(CONFIG_SM_HTTPC)
+	sm_at_httpc_socket_closed(sock->fd);
+#endif
 	init_socket(sock);
 
 	return ret;

--- a/doc/app/at_httpc.rst
+++ b/doc/app/at_httpc.rst
@@ -159,7 +159,7 @@ In hex mode (``<format>=1``), the data is ``2×<length>`` lower-case ASCII hex c
 * The ``<total_bytes>`` parameter is an integer.
    On successful completion, failure, or timeout, it contains the total number of response body bytes received by the HTTP client.
    For chunked transfer encoding this includes the raw framing bytes (chunk-size lines, ``\r\n`` separators, and the final ``0\r\n\r\n`` terminator).
-   On cancel (``status_code=-1`` from ``AT#XHTTPCCANCEL``), it contains the number of response body bytes already delivered to the host.
+   On cancel (``status_code=-1`` from ``AT#XHTTPCCANCEL`` or ``AT#XCLOSE``), it contains the number of response body bytes already delivered to the host.
 * The ``<connection_close>`` parameter is an integer.
   It is ``1`` when the server includes a ``Connection: close`` header in its response, indicating that the TCP connection will be closed after this response.
   It is ``0`` otherwise (keep-alive connection).
@@ -482,6 +482,10 @@ Syntax
   It identifies the socket of the request to cancel.
 
 An unsolicited ``#XHTTPCSTAT: <handle>,-1,<total_bytes>,<connection_close>`` notification is emitted after cancellation, where ``<total_bytes>`` is the number of response body bytes already delivered to the host.
+
+.. note::
+
+   Closing the socket with ``AT#XCLOSE`` while a request is active also cancels the request and emits ``#XHTTPCSTAT: <handle>,-1,<total_bytes>,<connection_close>`` before the socket is freed.
 
 Example
 ~~~~~~~


### PR DESCRIPTION
sm_at_httpc_socket_closed() finds any active request for the fd, sends a cancel status URC (#XHTTPCSTAT: handle,-1,<total_bytes>,<connection_close>) to the host, and frees the request. Without this, the stale http_request remained alive after the close.

Jira: SM-342