### PR TITLE
app: FOTA fixes

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -68,16 +68,9 @@ void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info)
 
 static void on_modem_dfu_res(int dfu_res, void *ctx)
 {
-	sm_fota_type = SM_FOTA_TYPE_MFW;
-	sm_fota_stage = FOTA_STAGE_COMPLETE;
-	sm_fota_status = FOTA_STATUS_ERROR;
-	sm_fota_info = dfu_res;
-
 	switch (dfu_res) {
 	case NRF_MODEM_DFU_RESULT_OK:
 		LOG_INF("Modem update OK. Running new firmware.");
-		sm_fota_status = FOTA_STATUS_OK;
-		sm_fota_info = 0;
 		break;
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
 	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
@@ -90,12 +83,24 @@ static void on_modem_dfu_res(int dfu_res, void *ctx)
 	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		LOG_ERR("Modem update postponed due to low voltage. "
 			"Reset the modem once you have sufficient power.");
-		sm_fota_stage = FOTA_STAGE_ACTIVATE;
 		break;
 	default:
 		LOG_ERR("Unhandled nrf_modem DFU result code 0x%x.", dfu_res);
 		break;
 	}
+
+	/* Update FOTA state only if a modem delta FOTA was in progress.
+	 * sm_fota_type is loaded from NVS; NONE means DFU or no update.
+	 */
+	if (sm_fota_type != SM_FOTA_TYPE_MFW) {
+		return;
+	}
+
+	sm_fota_stage  = (dfu_res == NRF_MODEM_DFU_RESULT_VOLTAGE_LOW)
+			? FOTA_STAGE_ACTIVATE : FOTA_STAGE_COMPLETE;
+	sm_fota_status = (dfu_res == NRF_MODEM_DFU_RESULT_OK)
+			? FOTA_STATUS_OK : FOTA_STATUS_ERROR;
+	sm_fota_info   = (dfu_res == NRF_MODEM_DFU_RESULT_OK) ? 0 : dfu_res;
 }
 
 static void check_app_fota_status(void)
@@ -107,11 +112,12 @@ static void check_app_fota_status(void)
 	 * image will be restored to the primary partition (so-called Revert).
 	 */
 	const int type = mcuboot_swap_type();
+	int ret = 0;
 
 	switch (type) {
 	/** Attempt to boot the contents of slot 0. */
 	case BOOT_SWAP_TYPE_NONE:
-		/* Normal reset, nothing happened, do nothing. */
+		/* Normal boot, nothing happened, do nothing. */
 		return;
 	/** Swap to slot 1. Absent a confirm command, revert back on next boot. */
 	case BOOT_SWAP_TYPE_TEST:
@@ -119,29 +125,27 @@ static void check_app_fota_status(void)
 	case BOOT_SWAP_TYPE_PERM:
 	/** Swap failed because image to be run is not valid. */
 	case BOOT_SWAP_TYPE_FAIL:
-		sm_fota_status = FOTA_STATUS_ERROR;
-		sm_fota_info = type;
 		break;
 	/** Swap back to alternate slot. A confirm changes this state to NONE. */
 	case BOOT_SWAP_TYPE_REVERT:
 		/* Happens on a successful application FOTA.
 		 * boot_write_img_confirmed() resolves the flash area via
-		 * zephyr,code-partition = slot0_ns_partition (fa_off=0x18000),
-		 * which places image_ok at abs 0x8dfe0 — 0x8000 past where MCUboot
-		 * reads the trailer. Use boot_write_img_confirmed_multi(0) instead:
-		 * it uses FLASH_AREA_IMAGE_PRIMARY(0) = slot0_partition (fa_off=0x10000),
-		 * writing image_ok at abs 0x85fe0 where MCUboot expects it.
+		 * slot_0_partition. It writes image_ok where MCUboot expects it.
 		 */
-		LOG_INF("FOTA: REVERT detected, calling boot_write_img_confirmed_multi(0)");
-		const int ret = boot_write_img_confirmed_multi(0);
-
-		LOG_INF("FOTA: boot_write_img_confirmed_multi ret=%d", ret);
-		sm_fota_info = ret;
-		sm_fota_status = ret ? FOTA_STATUS_ERROR : FOTA_STATUS_OK;
+		ret = boot_write_img_confirmed_multi(0);
+		LOG_INF("boot_write_img_confirmed_multi: %d", ret);
 		break;
 	}
-	sm_fota_type = SM_FOTA_TYPE_APP;
-	sm_fota_stage = FOTA_STAGE_COMPLETE;
+	/* Only report FOTA completion if an app FOTA was in progress.
+	 * sm_fota_type is loaded from NVS; NONE means DFU or no update.
+	 */
+	if (sm_fota_type != SM_FOTA_TYPE_APP) {
+		return;
+	}
+	sm_fota_status = (type == BOOT_SWAP_TYPE_REVERT && ret == 0)
+			? FOTA_STATUS_OK : FOTA_STATUS_ERROR;
+	sm_fota_info   = (type == BOOT_SWAP_TYPE_REVERT) ? ret : type;
+	sm_fota_stage  = FOTA_STAGE_COMPLETE;
 }
 
 static int bootloader_mode_init(void)
@@ -259,9 +263,8 @@ static int sm_main(void)
 	}
 
 #if defined(CONFIG_SM_FULL_FOTA)
-	if (sm_modem_full_fota) {
+	if (sm_fota_type == SM_FOTA_TYPE_FULL_MFW) {
 		sm_finish_modem_full_fota();
-		sm_fota_type = SM_FOTA_TYPE_FULL_MFW;
 	}
 #endif
 

--- a/app/src/sm_at_commands.c
+++ b/app/src/sm_at_commands.c
@@ -191,7 +191,7 @@ static void sm_modemreset(void)
 	++step;
 
 #if defined(CONFIG_SM_FULL_FOTA)
-	if (sm_modem_full_fota) {
+	if (sm_fota_type == SM_FOTA_TYPE_FULL_MFW) {
 		sm_finish_modem_full_fota();
 	}
 #endif

--- a/app/src/sm_at_fota.c
+++ b/app/src/sm_at_fota.c
@@ -45,8 +45,6 @@ enum sm_fota_operation {
 	SM_FOTA_ERASE_MFW = 9
 };
 
-bool sm_modem_full_fota;
-bool sm_fota_bl_pending_validate;
 uint32_t sm_fota_bl_version_before;
 
 enum sm_fota_image_type sm_fota_type = SM_FOTA_TYPE_NONE;
@@ -298,10 +296,6 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 		fota_path = NULL;
 		sm_fota_stage = FOTA_STAGE_ACTIVATE;
 		sm_fota_info = 0;
-		sm_modem_full_fota = (sm_fota_type == SM_FOTA_TYPE_FULL_MFW);
-#if defined(SM_FOTA_BL_SUPPORTED)
-		sm_fota_bl_pending_validate = (sm_fota_type == SM_FOTA_TYPE_MCUBOOT_BL);
-#endif
 		/* Save, in case reboot by reset */
 		sm_settings_fota_save();
 		urc_send_to(fota_pipe, "\r\n#XFOTA: %d,%d\r\n", sm_fota_stage, sm_fota_status);
@@ -508,7 +502,6 @@ SYS_INIT(sm_at_fota_init, APPLICATION, 0);
 
 void sm_fota_init_state(void)
 {
-	sm_modem_full_fota = false;
 	sm_fota_type = SM_FOTA_TYPE_NONE;
 	sm_fota_stage = FOTA_STAGE_INIT;
 	sm_fota_status = FOTA_STATUS_OK;
@@ -518,7 +511,7 @@ void sm_fota_init_state(void)
 void sm_fota_mcuboot_bl_boot_check(void)
 {
 #if defined(SM_FOTA_BL_SUPPORTED)
-	if (!sm_fota_bl_pending_validate) {
+	if (sm_fota_type != SM_FOTA_TYPE_MCUBOOT_BL) {
 		return;
 	}
 
@@ -541,7 +534,6 @@ void sm_fota_mcuboot_bl_boot_check(void)
 
 	sm_fota_type = SM_FOTA_TYPE_MCUBOOT_BL;
 	sm_fota_stage = FOTA_STAGE_COMPLETE;
-	sm_fota_bl_pending_validate = false;
 #endif
 }
 

--- a/app/src/sm_at_fota.c
+++ b/app/src/sm_at_fota.c
@@ -30,9 +30,6 @@ LOG_MODULE_REGISTER(sm_fota, CONFIG_SM_LOG_LEVEL);
 
 #define ERASE_POLL_TIME 2
 
-/* Some features need fota_download update */
-#define FOTA_FUTURE_FEATURE	0
-
 #if FIXED_PARTITION_EXISTS(s1_partition)
 #define SM_FOTA_BL_SUPPORTED
 #endif
@@ -361,9 +358,6 @@ static int handle_at_fota(enum at_parser_cmd_type cmd_type, struct at_parser *pa
 {
 	int err = -EINVAL;
 	uint16_t op;
-#if FOTA_FUTURE_FEATURE
-	static bool paused;
-#endif
 
 	switch (cmd_type) {
 	case AT_PARSER_CMD_TYPE_SET:
@@ -385,8 +379,11 @@ static int handle_at_fota(enum at_parser_cmd_type cmd_type, struct at_parser *pa
 		case SM_FOTA_START_FULL_FOTA:
 #endif
 		{
-			/* We cannot handle multiple simultaneous FOTA activations. */
-			if (sm_fota_stage == FOTA_STAGE_ACTIVATE) {
+			/* Only one FOTA session at a time. App and MCUboot share the
+			 * same update slot; modem and application updates are also
+			 * mutually exclusive.
+			 */
+			if (sm_fota_stage != FOTA_STAGE_INIT) {
 				err = -EBUSY;
 				break;
 			}
@@ -423,45 +420,40 @@ static int handle_at_fota(enum at_parser_cmd_type cmd_type, struct at_parser *pa
 				type = DFU_TARGET_IMAGE_TYPE_MODEM_DELTA;
 			}
 			err = do_fota_start(uri_ptr, uri_len, sec_tag, pdn_id, type);
-			sm_fota_init_state();
-			if (op == SM_FOTA_START_MFW) {
-				sm_fota_type = SM_FOTA_TYPE_MFW;
-			}
+			if (err == 0) {
+				sm_fota_init_state();
+				sm_fota_stage = FOTA_STAGE_DOWNLOAD;
+				if (op == SM_FOTA_START_MFW) {
+					sm_fota_type = SM_FOTA_TYPE_MFW;
+				}
 #if defined(CONFIG_SM_FULL_FOTA)
-			else if (op == SM_FOTA_START_FULL_FOTA) {
-				sm_fota_type = SM_FOTA_TYPE_FULL_MFW;
-			}
+				else if (op == SM_FOTA_START_FULL_FOTA) {
+					sm_fota_type = SM_FOTA_TYPE_FULL_MFW;
+				}
 #endif
 #if defined(SM_FOTA_BL_SUPPORTED)
-			else if (op == SM_FOTA_START_MCUBOOT_BL) {
-				sm_fota_type = SM_FOTA_TYPE_MCUBOOT_BL;
+				else if (op == SM_FOTA_START_MCUBOOT_BL) {
+					sm_fota_type = SM_FOTA_TYPE_MCUBOOT_BL;
 
-				/* Save the MCUboot version before FOTA. */
-				sm_util_mcuboot_active_version(&sm_fota_bl_version_before);
-				sm_settings_fota_save();
-			}
+					/* Save the MCUboot version before FOTA. */
+					sm_util_mcuboot_active_version(&sm_fota_bl_version_before);
+					sm_settings_fota_save();
+				}
 #endif
-			else {
-				sm_fota_type = SM_FOTA_TYPE_APP;
+				else {
+					sm_fota_type = SM_FOTA_TYPE_APP;
+				}
 			}
 			break;
 		}
-#if FOTA_FUTURE_FEATURE
-		case SM_FOTA_PAUSE_RESUME:
-			if (paused) {
-				fota_download_resume();
-				paused = false;
-			} else {
-				fota_download_pause();
-				paused = true;
-			}
-			err = 0;
-			break;
-#endif
 		case SM_FOTA_MFW_READ:
 			err = do_fota_mfw_read();
 			break;
 		case SM_FOTA_ERASE_MFW:
+			if (sm_fota_stage != FOTA_STAGE_INIT) {
+				err = -EBUSY;
+				break;
+			}
 			err = do_fota_erase_mfw();
 			break;
 		default:

--- a/app/src/sm_at_fota.h
+++ b/app/src/sm_at_fota.h
@@ -39,10 +39,6 @@ enum sm_fota_image_type {
 	SM_FOTA_TYPE_FULL_MFW,   /* Full modem FOTA */
 };
 
-/* Whether a modem full firmware update is to be activated. */
-extern bool sm_modem_full_fota;
-/** MCUboot bootloader FOTA: validate version increase after reboot. */
-extern bool sm_fota_bl_pending_validate;
 /** MCUboot bootloader FOTA: Active slot fw_info version before a bootloader update was started. */
 extern uint32_t sm_fota_bl_version_before;
 

--- a/app/src/sm_settings.c
+++ b/app/src/sm_settings.c
@@ -19,12 +19,6 @@ LOG_MODULE_REGISTER(sm_settings, CONFIG_SM_LOG_LEVEL);
 
 static int settings_set(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg)
 {
-	if (!strcmp(name, "modem_full_fota")) {
-		if (len != sizeof(sm_modem_full_fota))
-			return -EINVAL;
-		if (read_cb(cb_arg, &sm_modem_full_fota, len) > 0)
-			return 0;
-	}
 	if (!strcmp(name, "bootloader_mode_requested")) {
 		if (len != sizeof(sm_bootloader_mode_requested))
 			return -EINVAL;
@@ -37,16 +31,16 @@ static int settings_set(const char *name, size_t len, settings_read_cb read_cb, 
 		if (read_cb(cb_arg, &full_mfw_dfu_segment_type, len) > 0)
 			return 0;
 	}
-	if (!strcmp(name, "bl_fota_pend")) {
-		if (len != sizeof(sm_fota_bl_pending_validate))
-			return -EINVAL;
-		if (read_cb(cb_arg, &sm_fota_bl_pending_validate, len) > 0)
-			return 0;
-	}
 	if (!strcmp(name, "bl_fota_ver")) {
 		if (len != sizeof(sm_fota_bl_version_before))
 			return -EINVAL;
 		if (read_cb(cb_arg, &sm_fota_bl_version_before, len) > 0)
+			return 0;
+	}
+	if (!strcmp(name, "fota_type")) {
+		if (len != sizeof(sm_fota_type))
+			return -EINVAL;
+		if (read_cb(cb_arg, &sm_fota_type, len) > 0)
 			return 0;
 	}
 	/* Simply ignore obsolete settings that are not in use anymore.
@@ -93,18 +87,12 @@ int sm_settings_fota_save(void)
 {
 	int err;
 
-	err = settings_save_one("sm/modem_full_fota",
-		&sm_modem_full_fota, sizeof(sm_modem_full_fota));
-	if (err) {
-		return err;
-	}
-	err = settings_save_one("sm/bl_fota_pend", &sm_fota_bl_pending_validate,
-			      sizeof(sm_fota_bl_pending_validate));
-	if (err) {
-		return err;
-	}
-	return settings_save_one("sm/bl_fota_ver", &sm_fota_bl_version_before,
+	err = settings_save_one("sm/bl_fota_ver", &sm_fota_bl_version_before,
 				 sizeof(sm_fota_bl_version_before));
+	if (err) {
+		return err;
+	}
+	return settings_save_one("sm/fota_type", &sm_fota_type, sizeof(sm_fota_type));
 }
 
 int sm_settings_bootloader_mode_save(void)


### PR DESCRIPTION
- Prevent a second FOTA download or erase operation if there is currently one ongoing. Active operation can always be cancelled and new one can be started.

- Previously DFU for application, MCUboot or modem delta would show #XFOTA URC at startup. This is now removed.

Jira: SM-312