### PR TITLE
app: nrfcloud: Validate PLMN string length before parsing

### DIFF
--- a/app/src/sm_at_nrfcloud.c
+++ b/app/src/sm_at_nrfcloud.c
@@ -498,7 +498,7 @@ static int string_param_to_int(struct at_parser *parser, size_t idx, int *output
 static int plmn_param_string_to_mcc_mnc(struct at_parser *parser, size_t idx, int *mcc, int *mnc)
 {
 	int err;
-	char str_buf[7];
+	char str_buf[7] = {0};
 	size_t len = sizeof(str_buf);
 
 	err = at_parser_string_get(parser, idx, str_buf, &len);
@@ -507,7 +507,14 @@ static int plmn_param_string_to_mcc_mnc(struct at_parser *parser, size_t idx, in
 		return err;
 	}
 
-	str_buf[len] = '\0';
+	/* The MCC is 3 digits and the MNC is 2 or 3 digits, so a valid PLMN is 5 or 6
+	 * characters. Reject anything shorter, otherwise the fixed-offset parse below
+	 * would read past the end of the (network-controlled) field.
+	 */
+	if (len < 5) {
+		LOG_ERR("Invalid PLMN length: %zu", len);
+		return -EBADMSG;
+	}
 
 	/* Read MNC and store as integer. The MNC starts as the fourth character
 	 * in the string, following three characters long MCC.


### PR DESCRIPTION
The fix is copied from:
https://github.com/nrfconnect/sdk-nrf/pull/29498