### PR TITLE
drivers: nrf91-sm: adapt to updated modem_cellular API

### DIFF
--- a/drivers/nrf91-sm/nordic_nrf91sm.c
+++ b/drivers/nrf91-sm/nordic_nrf91sm.c
@@ -1,9 +1,10 @@
 #include <zephyr/drivers/modem/modem_cellular.h>
-#include <zephyr/device.h>
+
+#define DT_DRV_COMPAT nordic_nrf91_sm_v2
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(nordic_nrf91_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(nordic_nrf91_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_MATCH_DEFINE(xiccid_match, "%XICCID: ", "", modem_cellular_chat_on_iccid);
 MODEM_CHAT_MATCH_DEFINE(uicc_initialized, "%XSIM: 1", "", NULL);
@@ -46,11 +47,24 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(shutdown_chat_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(shutdown_chat_script, shutdown_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 10);
 
-static const struct modem_cellular_config_scripts nrf91_sm_scripts = {
-	.init = &init_chat_script,
-	.network = &network_chat_script,
-	.dial = &dial_chat_script,
-	.shutdown = &shutdown_chat_script,
+static const struct modem_cellular_vendor_config nrf91_sm_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &init_chat_script,
+		.network = &network_chat_script,
+		.dial = &dial_chat_script,
+		.shutdown = &shutdown_chat_script,
+	},
+	.unsol_matches = {
+		.matches = nordic_nrf91_unsol,
+		.size = ARRAY_SIZE(nordic_nrf91_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 0,
+	.reset_pulse_duration_ms = 500,
+	.startup_time_ms = 2000,
+	.shutdown_time_ms = 100,
+	.force_autostart = true,
 };
 
 #define NRF91SM_DEVICE(inst)                                                                       \
@@ -63,9 +77,6 @@ static const struct modem_cellular_config_scripts nrf91_sm_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 0, 500, 2000, 100, true, &nrf91_sm_scripts,           \
-				       &nordic_nrf91_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf91_sm_vendor)
 
-#define DT_DRV_COMPAT nordic_nrf91_sm_v2
 DT_INST_FOREACH_STATUS_OKAY(NRF91SM_DEVICE)
-#undef DT_DRV_COMPAT

--- a/west.yml
+++ b/west.yml
@@ -13,7 +13,7 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: 1c36e480279018abc54c42f60df729f9363be95a
+      revision: 16b9fb9100174fa363feef216d6f1ea407f4ed76
       import:
         name-allowlist:
           - cjson


### PR DESCRIPTION
Migrate to `modem_cellular_vendor_config` struct and updated `MODEM_CELLULAR_DEFINE_INSTANCE` macro, moving timing parameters and unsolicited match config into the vendor config struct. Also replace `MODEM_CELLULAR_UNSOL_DEFINE` with
`MODEM_CHAT_MATCHES_DEFINE` and bump the NCS revision.