### PR TITLE
manifest: Update NCS to v3.4.0-rc2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,11 @@ jobs:
           sudo apt-get update
           sudo apt install libc6-dev-i386
 
+      - name: Configure git identity for patch application
+        run: |
+          git config --global user.email "ci@github-actions"
+          git config --global user.name "GitHub Actions"
+
       - name: Prepare west project
         run: |
           python3 -m pip install west

--- a/west.yml
+++ b/west.yml
@@ -13,7 +13,7 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: 1c36e480279018abc54c42f60df729f9363be95a
+      revision: v3.4.0-rc2
       import:
         name-allowlist:
           - cjson


### PR DESCRIPTION
Updating NCS to v3.4.0-rc2.

GitHub Actions runner needs git identity for patch applications. This is used by TF-M build.

Jira: SM-354