### PR TITLE
app: nrfcloud: Make AT#XNRFCLOUD connect/disconnect idempotent

### DIFF
--- a/app/src/sm_at_nrfcloud.c
+++ b/app/src/sm_at_nrfcloud.c
@@ -180,6 +180,11 @@ static void nrfcloud_conn_work_fn(struct k_work *work)
 	int err;
 
 	if (nrfcloud_connect) {
+		/* Clear any stale connection (e.g. left over after an LTE drop) so a
+		 * reconnect request always starts from a clean state. Harmless
+		 * (-ENOTCONN) when there is no active connection.
+		 */
+		(void)nrf_cloud_coap_disconnect();
 		LOG_DBG("Connecting to nRF Cloud.");
 		err = nrf_cloud_coap_connect(NULL);
 		if (err) {
@@ -228,7 +233,7 @@ STATIC int handle_at_nrf_cloud(enum at_parser_cmd_type cmd_type, struct at_parse
 		if (err < 0) {
 			return err;
 		}
-		if (op == SM_NRF_CLOUD_CONNECT && !sm_nrf_cloud_ready) {
+		if (op == SM_NRF_CLOUD_CONNECT) {
 			if (param_count > 2) {
 				err = at_parser_num_get(parser, 2, &send_location);
 				if (send_location != 0 && send_location != 1) {
@@ -246,12 +251,17 @@ STATIC int handle_at_nrf_cloud(enum at_parser_cmd_type cmd_type, struct at_parse
 		} else if (op == SM_NRF_CLOUD_SEND && sm_nrf_cloud_ready) {
 			/* enter data mode */
 			err = enter_datamode(nrf_cloud_datamode_callback, 0);
-		} else if (op == SM_NRF_CLOUD_DISCONNECT && sm_nrf_cloud_ready) {
-			nrfcloud_connect = false;
-			k_work_submit_to_queue(&sm_work_q, &nrfcloud_conn_work);
+		} else if (op == SM_NRF_CLOUD_DISCONNECT) {
+			/* Disconnect is idempotent: if already disconnected there is
+			 * nothing to do, so just acknowledge with OK.
+			 */
+			if (sm_nrf_cloud_ready) {
+				nrfcloud_connect = false;
+				k_work_submit_to_queue(&sm_work_q, &nrfcloud_conn_work);
+			}
 			err = 0;
 		} else {
-			err = -EBUSY;
+			err = -EINVAL;
 		} break;
 
 	case AT_PARSER_CMD_TYPE_READ: {

--- a/doc/app/at_nrfcloud.rst
+++ b/doc/app/at_nrfcloud.rst
@@ -52,6 +52,16 @@ Syntax
 
   When ``<op>`` is ``2``, |SM| enters :ref:`sm_data_mode`.
 
+  .. note::
+     You can issue ``AT#XNRFCLOUD=1`` even when the device already reports a connection to nRF Cloud.
+     The command first closes any existing connection, and then performs a new connection and authentication.
+     Use this operation to recover the connection after the LTE link is lost and restored.
+     In that case, the device can still report a connection through the read command even though the connection is no longer valid.
+
+  .. note::
+     The disconnect operation is idempotent.
+     Issuing ``AT#XNRFCLOUD=0`` when the device is already disconnected returns ``OK`` and does nothing.
+
 * The ``<send_location>`` parameter is used only when the value of ``<op>`` is ``1``.
   It can have the following integer values:
 
@@ -109,6 +119,16 @@ Example
   #XNRFCLOUD: 0,1
 
   OK
+
+::
+
+  // Reconnect to nRF Cloud after the LTE link is lost and restored.
+  // The command closes the stale connection and establishes a new one.
+  AT#XNRFCLOUD=1
+
+  OK
+
+  #XNRFCLOUD: 1,0
 
 Read command
 ------------


### PR DESCRIPTION
Connect now always (re)establishes a clean connection so it can recover after an LTE drop, and disconnect returns OK when already disconnected. Use -EINVAL instead of -EBUSY for invalid operations.

Jira: SM-343