### PR TITLE
app: nrf_cloud: Use system heap for nrf_cloud libraries

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -256,10 +256,10 @@ config SM_NRF_CLOUD
 if SM_NRF_CLOUD
 config HEAP_MEM_POOL_ADD_SIZE_SM_NRF_CLOUD
 	int "Additional heap memory pool size for nRF Cloud support"
-	default 8192
+	default 1700
 	help
-	  Some libraries used by nRF Cloud use System Heap (k_malloc() / k_free()) for
-	  dynamic memory allocation.
+	  modem_jwt library used by nrf_cloud libraries, uses kernel heap for querying UUID.
+	  2x CONFIG_MODEM_JWT_MAX_LEN is the maximum it can use.
 endif # SM_NRF_CLOUD
 
 config SM_NRF_CLOUD_LOCATION

--- a/app/src/sm_at_nrfcloud.c
+++ b/app/src/sm_at_nrfcloud.c
@@ -277,10 +277,18 @@ static void sm_at_nrfcloud_init(int ret, void *ctx)
 {
 	static bool initialized;
 	int err;
+	/* We want to use the system heap for nRF Cloud library as we use for everything else. */
+	struct nrf_cloud_os_mem_hooks hooks = {
+		.malloc_fn = malloc,
+		.calloc_fn = calloc,
+		.free_fn = free,
+	};
 
 	if (initialized) {
 		return;
 	}
+
+	nrf_cloud_os_mem_hooks_init(&hooks);
 
 	err = nrf_cloud_coap_init();
 	if (err) {

--- a/app/tests/at_nrfcloud/include/net/nrf_cloud.h
+++ b/app/tests/at_nrfcloud/include/net/nrf_cloud.h
@@ -10,6 +10,7 @@
 #define NRF_CLOUD_TEST_STUB_H_
 
 #include <stddef.h>
+#include <net/nrf_cloud_os.h>
 
 /** Maximum length of the nRF Cloud client ID. */
 #define NRF_CLOUD_CLIENT_ID_MAX_LEN 64


### PR DESCRIPTION
Kernel heap (k_malloc) is used by nrf_cloud libraries by default. Changing it to use system heap (malloc) since this is what SM tries to use.
modem_jwt still uses kernel heap but we can reduce the heap size significantly.

Jira: SM-280