### PR TITLE
app: Show heap and stack stats

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -307,6 +307,27 @@ config SM_CMUX_CHANNEL_COUNT
 	  Number of channels to be used by the CMUX implementation.
 	  Each channel adds about 4 kB of RAM usage for buffers.
 
+config SM_DEBUG_STATS_HEAP
+	bool "Enable heap usage statistics"
+	default y
+	select SYS_HEAP_RUNTIME_STATS
+	help
+	  Enable heap usage statistics for debugging purposes through AT#XDBGSTATSMEM command.
+	  The statistics are printed to the log so use AT#XLOG=1 to enable logging.
+
+config SM_DEBUG_STATS_THREAD_STACK
+	bool "Enable threads' stack usage statistics"
+	depends on SM_DEBUG_STATS_HEAP
+	select THREAD_ANALYZER
+	select THREAD_NAME
+	help
+	  Enable threads' stack usage statistics for debugging purposes through
+	  the AT#XDBGSTATSMEM command. The statistics are printed to the log so use
+	  AT#XLOG=1 to enable logging.
+	  With default logging configurations, some of the stack usage metrics are dropped.
+	  You need to increase CONFIG_LOG_BUFFER_SIZE to 2048 or more to make it work.
+	  This feature will use 4-5 kB of FLASH.
+
 if SM_PPP
 
 config SM_PPP_FALLBACK_MTU

--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -204,3 +204,13 @@ tests:
       - SB_CONFIG_SECURE_BOOT_APPCORE=n
     platform_allow:
       - nrf9151dk/nrf9151/ns
+  serial_modem.debug_stats_stacks:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_SM_DEBUG_STATS_THREAD_STACK=y
+      - CONFIG_SYS_HEAP_INFO=y
+      - CONFIG_LOG_BUFFER_SIZE=2048
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    tags: exclude_integration

--- a/app/src/sm_at_commands.c
+++ b/app/src/sm_at_commands.c
@@ -14,6 +14,9 @@
 #include <zephyr/sys/reboot.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/debug/thread_analyzer.h>
+#include <sys_malloc.h>
 #include <dfu/dfu_target.h>
 #include <tfm/tfm_ioctl_api.h>
 #include <modem/at_parser.h>
@@ -372,3 +375,59 @@ STATIC int handle_at_xbootinfo(enum at_parser_cmd_type cmd_type, struct at_parse
 		return -EINVAL;
 	}
 }
+
+#if defined(CONFIG_SM_DEBUG_STATS_HEAP)
+
+/* The feature only works if logging is enabled and the log level is at least INF. */
+BUILD_ASSERT(IS_ENABLED(CONFIG_LOG), "AT#XDBGSTATSMEM requires CONFIG_LOG");
+BUILD_ASSERT(CONFIG_SM_LOG_LEVEL >= 3,
+	     "AT#XDBGSTATSMEM requires CONFIG_SM_LOG_LEVEL_INF or CONFIG_SM_LOG_LEVEL_DBG");
+
+extern struct sys_heap _system_heap;
+
+SM_AT_CMD_CUSTOM(xmemstats, "AT#XDBGSTATSMEM", handle_at_memstats);
+STATIC int handle_at_memstats(enum at_parser_cmd_type cmd_type, struct at_parser *, uint32_t)
+{
+	int ret;
+	struct sys_memory_stats kernel_stats;
+	struct sys_memory_stats malloc_stats;
+
+	if (cmd_type != AT_PARSER_CMD_TYPE_SET) {
+		return -EINVAL;
+	}
+
+	/* System heap stats */
+	ret = malloc_runtime_stats_get(&malloc_stats);
+	if (ret) {
+		LOG_WRN("Failed to read system heap stats, error: %d", ret);
+	} else {
+		LOG_INF("System heap stats:");
+		LOG_INF("  free:           %6d", malloc_stats.free_bytes);
+		LOG_INF("  allocated:      %6d", malloc_stats.allocated_bytes);
+		LOG_INF("  max. allocated: %6d", malloc_stats.max_allocated_bytes);
+	}
+
+	/* Kernel heap stats */
+	ret = sys_heap_runtime_stats_get(&_system_heap, &kernel_stats);
+	if (ret) {
+		LOG_WRN("Failed to read kernel heap stats, error: %d", ret);
+	} else {
+		LOG_INF("Kernel heap stats:");
+		LOG_INF("  free:           %6d", kernel_stats.free_bytes);
+		LOG_INF("  allocated:      %6d", kernel_stats.allocated_bytes);
+		LOG_INF("  max. allocated: %6d", kernel_stats.max_allocated_bytes);
+	}
+#if defined(CONFIG_SYS_HEAP_INFO)
+	LOG_INF("Kernel heap block information:");
+	sys_heap_print_info(&_system_heap, true);
+#endif
+
+	/* Thread stack usage statistics */
+#if defined(CONFIG_SM_DEBUG_STATS_THREAD_STACK)
+	LOG_INF("Thread stack stats:");
+	thread_analyzer_print(0);
+#endif
+
+	return 0;
+}
+#endif

--- a/app/tests/at_commands/CMakeLists.txt
+++ b/app/tests/at_commands/CMakeLists.txt
@@ -74,10 +74,11 @@ target_sources(app PRIVATE
 
 # Include directories - override headers first
 set(includes
-  "${PROJECT_SOURCE_DIR}/include/"
+  "${PROJECT_SOURCE_DIR}/include"
   "${PROJECT_SOURCE_DIR}/../../src"
   "${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include"
-  "${ZEPHYR_BASE}/include/"
+  "${ZEPHYR_BASE}/include"
+  "${ZEPHYR_BASE}/lib/libc/common/include"
   "${PROJECT_SOURCE_DIR}/../stubs"
 )
 

--- a/app/tests/at_nrfcloud/CMakeLists.txt
+++ b/app/tests/at_nrfcloud/CMakeLists.txt
@@ -89,11 +89,12 @@ target_sources(app PRIVATE
 #      at_commands test.
 #   3. Source directories and external include paths follow.
 set(includes
-  "${PROJECT_SOURCE_DIR}/include/"
-  "${PROJECT_SOURCE_DIR}/../at_commands/include/"
+  "${PROJECT_SOURCE_DIR}/include"
+  "${PROJECT_SOURCE_DIR}/../at_commands/include"
   "${PROJECT_SOURCE_DIR}/../../src"
   "${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include"
-  "${ZEPHYR_BASE}/include/"
+  "${ZEPHYR_BASE}/include"
+  "${ZEPHYR_BASE}/lib/libc/common/include"
   "${PROJECT_SOURCE_DIR}/../stubs"
 )
 

--- a/app/tests/at_socket/CMakeLists.txt
+++ b/app/tests/at_socket/CMakeLists.txt
@@ -81,10 +81,11 @@ target_sources(app PRIVATE
 
 # Include directories - override headers first
 set(includes
-  "${PROJECT_SOURCE_DIR}/include/"
+  "${PROJECT_SOURCE_DIR}/include"
   "${PROJECT_SOURCE_DIR}/../../src"
   "${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include"
-  "${ZEPHYR_BASE}/include/"
+  "${ZEPHYR_BASE}/include"
+  "${ZEPHYR_BASE}/lib/libc/common/include"
   "${PROJECT_SOURCE_DIR}/../stubs"
 )
 

--- a/doc/app/at_generic.rst
+++ b/doc/app/at_generic.rst
@@ -702,3 +702,123 @@ The ``<result>`` parameter returns an integer indicating the result of the re-in
    #. Connecting again using LTE.
    #. Restarting the service.
       For example, opening the socket and re-establishing the TCP connection.
+
+.. _SM_AT_DBGSTATSMEM:
+
+Memory statistics #XDBGSTATSMEM
+===============================
+
+.. note::
+
+   This AT command is `Experimental <Software maturity levels_>`_.
+
+Print heap and thread stack memory statistics to the log at the ``INF`` level.
+Since this is using the logging as an output, you must enable logging first by issuing the ``AT#XLOG=1`` command.
+
+The following statistics are printed:
+
+* System heap (``malloc`` heap) - Free bytes, allocated bytes, and peak allocated bytes.
+* Kernel heap (``k_malloc`` heap) - Free bytes, allocated bytes, and peak allocated bytes.
+* Kernel heap block information - This is only available when the ``CONFIG_SYS_HEAP_INFO`` Kconfig option is enabled.
+* Thread stack usage statistics:
+
+  * This is only available when the :ref:`CONFIG_SM_DEBUG_STATS_THREAD_STACK <CONFIG_SM_DEBUG_STATS_THREAD_STACK>` Kconfig option is enabled.
+  * Setting the ``CONFIG_LOG_BUFFER_SIZE`` Kconfig option to 2048 or more is required to avoid dropping some of the log entries showing stack usage statistics.
+
+This command is available when the firmware is built with the :ref:`CONFIG_SM_DEBUG_STATS_HEAP <CONFIG_SM_DEBUG_STATS_HEAP>` Kconfig option enabled.
+In addition, the ``CONFIG_LOG`` Kconfig option and the ``CONFIG_SM_LOG_LEVEL_DBG`` or ``CONFIG_SM_LOG_LEVEL_INF`` Kconfig option must be enabled.
+
+Set command
+-----------
+
+::
+
+   AT#XDBGSTATSMEM
+
+The command prints memory statistics to the log and returns ``OK``.
+No memory information is returned in the AT response.
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.
+
+Example
+-------
+
+Query memory statistics:
+::
+
+   AT#XLOG=1
+   OK
+   AT#XDBGSTATSMEM
+   OK
+
+These commands will print the following output in the log:
+::
+
+   [00:00:36.270,965] <inf> sm_at: System heap stats:
+   [00:00:36.270,996] <inf> sm_at:   free:            45844
+   [00:00:36.270,996] <inf> sm_at:   allocated:         472
+   [00:00:36.271,026] <inf> sm_at:   max. allocated:    472
+   [00:00:36.271,026] <inf> sm_at: Kernel heap stats:
+   [00:00:36.271,057] <inf> sm_at:   free:             1892
+   [00:00:36.271,057] <inf> sm_at:   allocated:           0
+   [00:00:36.271,057] <inf> sm_at:   max. allocated:   1280
+
+The output appears as follows when ``CONFIG_SM_DEBUG_STATS_THREAD_STACK`` and ``CONFIG_SYS_HEAP_INFO`` Kconfig options are enabled.
+::
+
+   [00:01:16.852,478] <inf> sm_at: System heap stats:
+   [00:01:16.853,393] <inf> sm_at:   free:            48292
+   [00:01:16.854,431] <inf> sm_at:   allocated:         472
+   [00:01:16.855,438] <inf> sm_at:   max. allocated:   1344
+   [00:01:16.856,445] <inf> sm_at: Kernel heap stats:
+   [00:01:16.857,360] <inf> sm_at:   free:             1892
+   [00:01:16.858,398] <inf> sm_at:   allocated:           0
+   [00:01:16.859,405] <inf> sm_at:   max. allocated:   1280
+   [00:01:16.860,412] <inf> sm_at: Kernel heap block information:
+   Heap at 0x20028d40 contains 245 units in 8 buckets
+
+     bucket#    min units        total      largest      largest
+                threshold       chunks      (units)      (bytes)
+     -----------------------------------------------------------
+           7          128            1          237         1896
+
+   Chunk dump:
+   chunk    0: [*] size=8    left=0    right=8
+   chunk    8: [-] size=237  left=0    right=245
+   chunk  245: [*] size=0    left=8    right=245
+
+   1892 free bytes, 0 allocated bytes, overhead = 72 bytes (3.7%)
+   [00:01:16.869,781] <inf> sm_at: Thread stack stats:
+   Thread analyze:
+    ppp_tx              : STACK: unused 796 usage 228 / 1024 (22 %); CPU: 0 %
+                        : Total CPU cycles used: 2
+    trace_thread        : STACK: unused 460 usage 308 / 768 (40 %); CPU: 0 %
+                        : Total CPU cycles used: 3
+    coap_client_recv_thread: STACK: unused 1276 usage 772 / 2048 (37 %); CPU: 0 %
+                        : Total CPU cycles used: 67
+    nrf_provisioning_work_q: STACK: unused 1812 usage 236 / 2048 (11 %); CPU: 0 %
+                        : Total CPU cycles used: 2
+    date_time_work_q    : STACK: unused 492 usage 788 / 1280 (61 %); CPU: 0 %
+                        : Total CPU cycles used: 32
+    ppp_data_passing    : STACK: unused 1564 usage 484 / 2048 (23 %); CPU: 0 %
+                        : Total CPU cycles used: 2
+    downloader          : STACK: unused 3844 usage 252 / 4096 (6 %); CPU: 0 %
+                        : Total CPU cycles used: 2
+    net_mgmt            : STACK: unused 596 usage 204 / 800 (25 %); CPU: 0 %
+                        : Total CPU cycles used: 1
+    sysworkq            : STACK: unused 3180 usage 916 / 4096 (22 %); CPU: 0 %
+                        : Total CPU cycles used: 475
+    idle                : STACK: unused 252 usage 68 / 320 (21 %); CPU: 99 %
+                        : Total CPU cycles used: 2506299
+    sm_work_q           : STACK: unused 812 usage 3284 / 4096 (80 %); CPU: 0 %
+                        : Total CPU cycles used: 4467
+    ISR0                : STACK: unused 1588 usage 460 / 2048 (22 %); CPU: 0 %
+                        : Total CPU cycles used: 0

--- a/doc/app/sm_configuration.rst
+++ b/doc/app/sm_configuration.rst
@@ -270,6 +270,18 @@ CONFIG_SM_DFU_MODEM_FULL - Enable full modem DFU
    This option enables support for full modem firmware updates using the ``AT#XDFUINIT``, ``AT#XDFUWRITE``, and ``AT#XDFUAPPLY`` commands.
    See the :ref:`DFU_AT_commands` for more information.
 
+.. _CONFIG_SM_DEBUG_STATS_HEAP:
+
+CONFIG_SM_DEBUG_STATS_HEAP - Enable heap memory statistics
+   This option enables the ``AT#XDBGSTATSMEM`` command for printing heap memory statistics.
+   See the :ref:`SM_AT_DBGSTATSMEM` for more information.
+
+.. _CONFIG_SM_DEBUG_STATS_THREAD_STACK:
+
+CONFIG_SM_DEBUG_STATS_THREAD_STACK - Enable thread stack memory statistics
+   This option enables thread stack memory statistics in the ``AT#XDBGSTATSMEM`` command.
+   See the :ref:`SM_AT_DBGSTATSMEM` for more information.
+
 .. _sm_config_files:
 
 Configuration files


### PR DESCRIPTION
Add new AT command `AT#XDBGSTATSMEM` to log heap and stack information. It is now possible to see how much heap/stack is available and what has been the maximum usage.