### PR TITLE
app: provisioning: Increase heap memory pool size

### DIFF
--- a/app/nrf-device-provisioning.conf
+++ b/app/nrf-device-provisioning.conf
@@ -28,8 +28,8 @@ CONFIG_NRF_PROVISIONING_CODEC=y
 CONFIG_NRF_PROVISIONING_CBOR=y
 CONFIG_ZCBOR=y
 
-# Max provisioning commands per response
-CONFIG_NRF_PROVISIONING_CBOR_RECORDS=10
+# Max provisioning commands in a single provisioning exchange
+CONFIG_NRF_PROVISIONING_CBOR_RECORDS=5
 
 # Adjust provisioning and buffer sizes to handle nRF Cloud certs
 CONFIG_NRF_PROVISIONING_RX_BUF_SZ=2304
@@ -44,3 +44,6 @@ CONFIG_COAP_CLIENT=y
 # Modem key management
 CONFIG_MODEM_KEY_MGMT=y
 CONFIG_MODEM_ATTEST_TOKEN=y
+
+# Increase additional heap memory pool size for nRF Device Provisioning support
+CONFIG_HEAP_MEM_POOL_ADD_SIZE_SM_NRF_CLOUD=3072


### PR DESCRIPTION
nRF Device Provisioning library uses kernel heap for dynamic memory allocation.
Increase the heap size to 3072 bytes and limit the maximum number of provisioning commands to 5 in a single request.

Jira: SM-360