### PR TITLE
app: Enable full modem DFU for nRF91M1

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="overlay-nrf91m1.overlay;overlay-trace-backend.overlay"
     extra_configs:
       - CONFIG_SM_LOG_LEVEL_DBG=y
+      - CONFIG_SM_DFU_MODEM_FULL=y
     platform_allow:
       - nrf9151dk/nrf9151/ns
   serial_modem.default:


### PR DESCRIPTION
Full modem DFU will be enabled for nRF91M1 configuration.