### PR TITLE
app: mqtt: Add optional data length parameter to AT#XMQTTPUB

### DIFF
--- a/app/src/sm_at_mqtt.c
+++ b/app/src/sm_at_mqtt.c
@@ -671,6 +671,7 @@ static int handle_at_mqtt_publish(enum at_parser_cmd_type cmd_type, struct at_pa
 	size_t topic_sz = MQTT_MAX_TOPIC_LEN;
 	const char *pub_msg_ptr = NULL;
 	size_t msg_sz = 0;
+	int data_len = 0;
 
 	if (!ctx.connected) {
 		return -ENOTCONN;
@@ -700,6 +701,22 @@ static int handle_at_mqtt_publish(enum at_parser_cmd_type cmd_type, struct at_pa
 				return err;
 			}
 		}
+		if (param_count > 5) {
+			err = at_parser_num_get(parser, 5, &data_len);
+			if (err) {
+				return err;
+			}
+			/* The payload must fit in the data mode buffer, as it is
+			 * published as a single message.
+			 */
+			if (data_len < 0 || data_len > CONFIG_SM_DATAMODE_BUF_SIZE) {
+				return -EINVAL;
+			}
+			if (data_len > 0 && msg_sz > 0) {
+				/* <data_len> only applies to data mode */
+				return -EINVAL;
+			}
+		}
 
 		/* common publish parameters*/
 		if (qos <= MQTT_QOS_2_EXACTLY_ONCE) {
@@ -721,14 +738,14 @@ static int handle_at_mqtt_publish(enum at_parser_cmd_type cmd_type, struct at_pa
 		}
 		if (pub_msg_ptr == NULL || msg_sz == 0) {
 			/* Publish payload in data mode */
-			err = enter_datamode(mqtt_datamode_callback, 0);
+			err = enter_datamode(mqtt_datamode_callback, data_len);
 		} else {
 			err = do_mqtt_publish((uint8_t *)pub_msg_ptr, msg_sz);
 		}
 		break;
 
 	case AT_PARSER_CMD_TYPE_TEST:
-		rsp_send("\r\n#XMQTTPUB: <topic>,<msg>,(0,1,2),(0,1)\r\n");
+		rsp_send("\r\n#XMQTTPUB: <topic>,<msg>,(0,1,2),(0,1)[,<data_len>]\r\n");
 		err = 0;
 		break;
 

--- a/doc/app/at_mqtt.rst
+++ b/doc/app/at_mqtt.rst
@@ -501,7 +501,7 @@ Syntax
 
 ::
 
-   AT#XMQTTPUB=<topic>[,<msg>[,<qos>[,<retain>]]]
+   AT#XMQTTPUB=<topic>[,<msg>[,<qos>[,<retain>[,<data_len>]]]]
 
 
 * The ``<topic>`` parameter is a string.
@@ -524,6 +524,15 @@ Syntax
 * The ``<retain>`` parameter is an integer.
   Its default value is ``0``.
   When ``1``, it indicates that the broker should store the message persistently.
+* The ``<data_len>`` parameter is optional and only used when ``<msg>`` is empty (data mode).
+  It sets the number of bytes of payload to publish in data mode.
+  When the required number of bytes are received, the payload is published and the data mode is exited.
+  The termination command :ref:`CONFIG_SM_DATAMODE_TERMINATOR <CONFIG_SM_DATAMODE_TERMINATOR>` is not used in this case.
+  The value must not exceed the value configured in the
+  :ref:`CONFIG_SM_DATAMODE_BUF_SIZE <CONFIG_SM_DATAMODE_BUF_SIZE>`, Kconfig option, as the
+  payload must fit within the data mode buffer to be published as a single message.
+  The value ``0`` is equivalent to omitting the parameter.
+  Specifying a non-zero ``<data_len>`` together with a non-empty ``<msg>`` results in an error.
 
 Response syntax
 ~~~~~~~~~~~~~~~
@@ -557,6 +566,13 @@ Examples
    AT#XMQTTPUB="nrf91/sm/mqtt/topic0"
    OK
    {"msg":"Test Json publish"}+++
+   #XDATAMODE: 0
+
+::
+
+   AT#XMQTTPUB="nrf91/sm/mqtt/topic0","",0,0,23
+   OK
+   Test message, 23 bytes.
    #XDATAMODE: 0
 
 ::


### PR DESCRIPTION
Allow `AT#XMQTTPUB` to specify the number of payload bytes to read in data mode (as `AT#XSEND`, `AT#XCOAPCPUT`, `AT#XHTTPCREQ` and others already do).

When <data_len> is given, data mode collects exactly that many bytes and publishes them, instead of scanning for the terminator string. This allows publishing binary payloads that may contain the terminator sequence, and avoids terminator escaping issues.

Tested on local hardware (a Circuit Dojo nRF9151 Feather) against a public MQTT server, both with and without the extra data length parameter.