### PR TITLE
sm_at_host: replace strcpy() with length-bounded memcpy() in URC path

### DIFF
--- a/app/src/sm_at_host.c
+++ b/app/src/sm_at_host.c
@@ -1048,7 +1048,8 @@ static int sm_at_send_internal(struct sm_at_host_ctx *ctx, const uint8_t *data, 
 				LOG_DBG("No context available for URC: %s", (const char *)data);
 				return -EIO;
 			}
-			LOG_DBG("URC default pipe=%p: %s", ctx->pipe, (const char *)data);
+			LOG_DBG("URC default pipe=%p: %.*s", ctx->pipe, (int)len,
+				(const char *)data);
 			ret = ring_buf_put(&urc_buf, data, len);
 			if (ret < len) {
 				LOG_ERR("URC buffer full, dropped %d bytes", len - ret);
@@ -1057,7 +1058,7 @@ static int sm_at_send_internal(struct sm_at_host_ctx *ctx, const uint8_t *data, 
 				return -EIO;
 			}
 		} else {
-			LOG_DBG("URC to pipe=%p: %s", ctx->pipe, (const char *)data);
+			LOG_DBG("URC to pipe=%p: %.*s", ctx->pipe, (int)len, (const char *)data);
 			/* Pipe specific URC */
 			struct urc_msg *msg = calloc(1, sizeof(struct urc_msg) + len + 1);
 
@@ -1065,7 +1066,8 @@ static int sm_at_send_internal(struct sm_at_host_ctx *ctx, const uint8_t *data, 
 				LOG_ERR("Failed to allocate URC message");
 				return -ENOMEM;
 			}
-			strcpy(msg->urc, (const char *)data);
+			memcpy(msg->urc, data, len);
+			msg->urc[len] = '\0';
 			K_SPINLOCK(&sm_at_host_lock) {
 				sys_slist_append(&ctx->buffered_urcs, &msg->node);
 			}


### PR DESCRIPTION
sm_at_send_internal()'s pipe-specific URC path allocated msg->urc (a flexible array member) to exactly len + 1 bytes, then filled it with strcpy(msg->urc, data). This relies on an implicit, unenforced invariant that data is NUL-terminated at exactly len bytes -- true today only because every call site formats data via vsnprintf() into a bounded buffer first. Nothing in this function checks that invariant, so a future change to a caller (or to rsp_send_internal()'s handling of a negative vsnprintf() return) could silently reintroduce a heap buffer overflow with no compiler warning.

Fix: use memcpy(msg->urc, data, len) followed by an explicit NUL terminator, since len is already known precisely -- removing the implicit dependency on NUL-termination entirely (CERT-C STR31-C).

The existing app/tests/at_sms/ suite's
test_xsms_concat_max_size_no_overflow test already exercises this exact code path (a 376+ byte URC delivered via urc_send_to()) as a regression test.