### PR TITLE
sm_at_icmp: skip undersized datagrams in the ping receive loop

### DIFF
--- a/app/src/sm_at_icmp.c
+++ b/app/src/sm_at_icmp.c
@@ -328,8 +328,14 @@ wait_for_data:
 			}
 		}
 		if (len < header_len) {
-			/* Data length error, ignore "silently" */
+			/* Data length error, ignore "silently" and wait for the
+			 * next datagram. Without this continue, the checks below
+			 * would inspect stale bytes left in buf by a previous
+			 * iteration (or the zero-initialised allocation) and could
+			 * accept them as a valid echo reply (CERT EXP33-C).
+			 */
 			LOG_ERR("zsock_recv() wrong data (%d)", len);
+			continue;
 		}
 
 		if ((rep == ICMP_ECHO_REP && buf[IP_PROTOCOL_POS] == IPPROTO_ICMP) ||


### PR DESCRIPTION
The ping receive loop logged an error when a received datagram was shorter than the IP header, but then fell through and indexed buf at IP_PROTOCOL_POS / IP_NEXT_HEADER_POS anyway. Those bytes are either uninitialised or left over from a previous datagram, so a short packet could be misinterpreted as a valid echo reply.

Continue the loop instead. The loop top re-evaluates the remaining timeout, so this cannot spin indefinitely.

CERT EXP33-C (do not read uninitialized memory).