### PR TITLE
sm_at_httpc: reject a negative Content-Length header

### DIFF
--- a/app/src/sm_at_httpc.c
+++ b/app/src/sm_at_httpc.c
@@ -567,6 +567,7 @@ static int parse_content_length(const char *buf, const char *header_end, int *le
 {
 	char *cl_header;
 	char *value_start;
+	int parsed;
 	int ret;
 
 	cl_header = strstr(buf, "Content-Length:");
@@ -583,10 +584,23 @@ static int parse_content_length(const char *buf, const char *header_end, int *le
 		value_start++;
 	}
 
-	ret = sscanf(value_start, "%d", length);
+	ret = sscanf(value_start, "%d", &parsed);
 	if (ret != 1) {
 		return -EINVAL;
 	}
+
+	/* A negative Content-Length is never valid. The caller distinguishes
+	 * "no Content-Length" (treated as chunked/until-close) from a known
+	 * body length using the sign of this field, so a malicious or broken
+	 * server could otherwise flip the framing mode (CERT INT31-C). Do not
+	 * publish the value to the caller unless it validates.
+	 */
+	if (parsed < 0) {
+		LOG_WRN("Rejecting negative Content-Length: %d", parsed);
+		return -EINVAL;
+	}
+
+	*length = parsed;
 
 	return 0;
 }


### PR DESCRIPTION
parse_content_length() scanned the header value directly into the caller's output parameter with "%d", so a server sending "Content-Length: -1" both succeeded and published a negative length. The caller uses the sign of that field to choose between known-length and until-close body framing, so a hostile server could flip the framing mode.

Parse into a local, reject negative values with -EINVAL, and only then write the caller's output.

CERT INT31-C.