### PR TITLE
sm_at_nrfcloud: bound Wi-Fi AP and neighbor cell counts

### DIFF
--- a/app/src/sm_at_nrfcloud.c
+++ b/app/src/sm_at_nrfcloud.c
@@ -100,6 +100,21 @@ static struct lte_lc_cells_info *nrfcloud_cell_data;
 
 #define WIFI_APS_BEGIN_IDX 3
 
+/* Upper bound on the number of Wi-Fi access points accepted in one
+ * AT#XNRFCLOUDPOS request. param_count originates from the AT parser and is
+ * only bounded by CONFIG_SM_AT_BUF_SIZE, so cap it explicitly before it is
+ * used to size a heap allocation (CERT INT30-C, MEM35-C). The value is far
+ * above any realistic scan result set submitted for Wi-Fi positioning.
+ */
+#define WIFI_APS_MAX 64
+
+/* Upper bound on the neighbor cell count accepted from an %NCELLMEAS response.
+ * The count is derived by counting commas in a modem-supplied string and is
+ * stored in a uint8_t, so cap it explicitly before it is used to size an
+ * allocation or to compute a parameter index (CERT INT31-C, MEM35-C).
+ */
+#define NCELLMEAS_NCELLS_MAX 32
+
 /* nRF Cloud location request Wi-Fi data. */
 static struct wifi_scan_info nrfcloud_wifi_data;
 
@@ -369,8 +384,16 @@ STATIC int handle_at_nrf_cloud_pos(enum at_parser_cmd_type cmd_type,
 	}
 
 	if (wifi_pos) {
-		nrfcloud_wifi_data.ap_info = malloc(
-			sizeof(*nrfcloud_wifi_data.ap_info) * (param_count - WIFI_APS_BEGIN_IDX));
+		const uint32_t ap_count = param_count - WIFI_APS_BEGIN_IDX;
+
+		if (ap_count > WIFI_APS_MAX) {
+			LOG_ERR("Too many Wi-Fi access points: %u (max %d)", ap_count,
+				WIFI_APS_MAX);
+			return -E2BIG;
+		}
+
+		nrfcloud_wifi_data.ap_info =
+			malloc(sizeof(*nrfcloud_wifi_data.ap_info) * ap_count);
 		if (!nrfcloud_wifi_data.ap_info) {
 			return -ENOMEM;
 		}
@@ -854,6 +877,12 @@ static uint32_t neighborcell_count_get(const char *at_response)
 	ncell_elements = comma_count - (AT_NCELLMEAS_PRE_NCELLS_PARAMS_COUNT - 1) + 1;
 	ncell_count = ncell_elements / AT_NCELLMEAS_NCELLS_PARAMS_COUNT;
 
+	if (ncell_count > NCELLMEAS_NCELLS_MAX) {
+		LOG_WRN("Neighbor cell count %u exceeds the supported maximum %d, clamping.",
+			ncell_count, NCELLMEAS_NCELLS_MAX);
+		ncell_count = NCELLMEAS_NCELLS_MAX;
+	}
+
 	return ncell_count;
 }
 
@@ -1136,6 +1165,12 @@ static int parse_ncellmeas_gci(const char *at_response, struct lte_lc_cells_info
 			goto clean_exit;
 		}
 		parsed_ncells_count = tmp_short;
+		if (parsed_ncells_count > NCELLMEAS_NCELLS_MAX) {
+			LOG_ERR("Neighbor cell count %d exceeds the supported maximum %d.",
+				parsed_ncells_count, NCELLMEAS_NCELLS_MAX);
+			err = -E2BIG;
+			goto clean_exit;
+		}
 
 		if (is_serving_cell) {
 			/* This the current/serving cell.

--- a/app/tests/at_nrfcloud/src/nrf_modem_at_wrapper.c
+++ b/app/tests/at_nrfcloud/src/nrf_modem_at_wrapper.c
@@ -38,7 +38,11 @@ int test_at_nrfcloud_ncellmeas_resp_ret;
 
 int nrf_modem_at_cmd(void *buf, size_t buf_size, const char *fmt, ...)
 {
-	char at_cmd[256];
+	/* Sized to CONFIG_SM_AT_BUF_SIZE: a smaller buffer silently truncates long
+	 * AT commands (for example a Wi-Fi positioning request with many access
+	 * points) before the handler ever sees them.
+	 */
+	static char at_cmd[4096];
 	va_list args;
 	int ret;
 

--- a/app/tests/at_nrfcloud/src/test_at_nrfcloud.c
+++ b/app/tests/at_nrfcloud/src/test_at_nrfcloud.c
@@ -35,6 +35,7 @@
  */
 
 #include <unity.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -413,6 +414,70 @@ void test_xnrfcloudpos_wifi_no_aps(void)
 	clear_captured_response();
 
 	send_at_command("AT#XNRFCLOUDPOS=0,1\r\n");
+	resp = get_captured_response();
+	TEST_ASSERT_NOT_NULL(strstr(resp, "ERROR"));
+
+	clear_captured_response();
+	helper_xnrfcloud_disconnect_ok();
+}
+
+/* Builds an AT#XNRFCLOUDPOS Wi-Fi request carrying ap_count access points. */
+static void build_wifi_pos_cmd(char *cmd, size_t cmd_size, int ap_count)
+{
+	int off = snprintf(cmd, cmd_size, "AT#XNRFCLOUDPOS=0,1");
+
+	for (int i = 0; i < ap_count; i++) {
+		off += snprintf(&cmd[off], cmd_size - off, ",\"AA:BB:CC:DD:%02X:%02X\"",
+				(i >> 8) & 0xFF, i & 0xFF);
+		TEST_ASSERT_TRUE(off < (int)cmd_size);
+	}
+	off += snprintf(&cmd[off], cmd_size - off, "\r\n");
+	TEST_ASSERT_TRUE(off < (int)cmd_size);
+}
+
+/*
+ * Regression test for the Wi-Fi access point count cap.
+ *
+ * The AP count is derived from the AT parameter count, which is bounded only by
+ * CONFIG_SM_AT_BUF_SIZE, and is multiplied into a malloc() size. The handler
+ * caps it at WIFI_APS_MAX (64). Verify the boundary: exactly WIFI_APS_MAX APs
+ * is still accepted, one more is rejected.
+ */
+void test_xnrfcloudpos_wifi_ap_count_cap(void)
+{
+	/* Must match WIFI_APS_MAX in sm_at_nrfcloud.c. */
+	const int wifi_aps_max = 64;
+	static struct nrf_cloud_location_result loc_result = {
+		.type = LOCATION_TYPE_WIFI,
+		.lat  = 60.1699,
+		.lon  = 24.9384,
+		.unc  = 50,
+	};
+	static char cmd[4096];
+
+	helper_xnrfcloud_connect_ok();
+	clear_captured_response();
+
+	/* Exactly at the cap: accepted. */
+	__cmock_nrf_cloud_coap_location_get_ExpectAnyArgsAndReturn(0);
+	__cmock_nrf_cloud_coap_location_get_ReturnThruPtr_result(&loc_result);
+
+	build_wifi_pos_cmd(cmd, sizeof(cmd), wifi_aps_max);
+	k_sleep(K_MSEC(1));
+	send_at_command(cmd);
+	k_sleep(K_MSEC(1));
+
+	resp = get_captured_response();
+	TEST_ASSERT_NOT_NULL(strstr(resp, "OK"));
+	TEST_ASSERT_NULL(strstr(resp, "ERROR"));
+
+	k_sleep(K_MSEC(10));
+	clear_captured_response();
+
+	/* One past the cap: rejected before any allocation is sized from it. */
+	build_wifi_pos_cmd(cmd, sizeof(cmd), wifi_aps_max + 1);
+	send_at_command(cmd);
+
 	resp = get_captured_response();
 	TEST_ASSERT_NOT_NULL(strstr(resp, "ERROR"));
 

--- a/app/tests/stubs/uart_stubs.c
+++ b/app/tests/stubs/uart_stubs.c
@@ -18,7 +18,11 @@ LOG_MODULE_REGISTER(uart_stubs, LOG_LEVEL_DBG);
 
 const struct device *const sm_uart_dev;
 uint32_t sm_uart_baudrate = 115200;
-RING_BUF_DECLARE(uart_rx_ring_buf, 1024);
+/* Sized to match CONFIG_SM_AT_BUF_SIZE so that tests can inject a maximum
+ * length AT command in one go. A smaller buffer silently truncates the command
+ * and leaves a partial line behind, which wedges every subsequent test.
+ */
+RING_BUF_DECLARE(uart_rx_ring_buf, 4096);
 static K_SEM_DEFINE(tx_done, 0, 1);
 
 static void tx_done_fn(struct k_work *work)
@@ -56,10 +60,15 @@ static int pipe_receive(void *data, uint8_t *buf, size_t size)
 {
 	struct modem_pipe *pipe = (struct modem_pipe *)data;
 
-	if (ring_buf_size_get(&uart_rx_ring_buf) > size) {
+	int ret = ring_buf_get(&uart_rx_ring_buf, buf, size);
+
+	/* Re-arm after draining this chunk. Notifying before the read can be lost,
+	 * which stalls any input longer than one receive buffer.
+	 */
+	if (ring_buf_size_get(&uart_rx_ring_buf) > 0) {
 		modem_pipe_notify_receive_ready(pipe);
 	}
-	return ring_buf_get(&uart_rx_ring_buf, buf, size);
+	return ret;
 }
 
 static int pipe_close(void *data)


### PR DESCRIPTION
Two externally-influenced counts were used to size allocations and indices without an upper bound:

- handle_at_nrf_cloud_pos() derived the Wi-Fi access point count from the AT parameter count, which is limited only by the 4096-byte AT buffer, and multiplied it straight into a malloc() size.
- neighborcell_count_get() derives the neighbor cell count by counting commas in an %NCELLMEAS response, and parse_ncellmeas_gci() takes it from a parsed AT parameter. Both are stored in the uint8_t lte_lc_cells_info.ncells_count and are later multiplied into a parameter index, so a large value truncates and desynchronises parsing.

Cap the AP count at WIFI_APS_MAX (reject with -E2BIG), clamp the comma-derived neighbor count, and reject an out-of-range parsed count.

CERT INT30-C, INT31-C, MEM35-C.