### PR TITLE
sm_cmux: clear uart_pipe when cmux_start() fails

### DIFF
--- a/app/src/sm_cmux.c
+++ b/app/src/sm_cmux.c
@@ -228,14 +228,6 @@ static int cmux_start(void)
 {
 	int ret;
 
-	if (sm_cmux_is_started()) {
-		ret = modem_pipe_open(cmux.uart_pipe, K_SECONDS(CONFIG_SM_MODEM_PIPE_TIMEOUT));
-		if (!ret) {
-			LOG_INF("CMUX resumed.");
-		}
-		return ret;
-	}
-
 	/* Get the UART pipe (already open and attached to AT host) */
 	cmux.uart_pipe = sm_uart_pipe_get();
 	if (!cmux.uart_pipe) {
@@ -248,13 +240,21 @@ static int cmux_start(void)
 	ret = sm_at_host_set_pipe(ctx, cmux.dlcis[cmux.at_channel].pipe);
 	if (ret) {
 		LOG_ERR("Failed to switch AT host to CMUX DLCI pipe. (%d)", ret);
+		/* uart_pipe is what sm_cmux_is_started() reports on. Leaving it set
+		 * after a failed start would make every later AT#XCMUX take the
+		 * "resume" path and let AT#XCMUXCLD release a CMUX instance that was
+		 * never attached.
+		 */
+		cmux.uart_pipe = NULL;
 		return ret;
 	}
 
-	/* Attach CMUX to UART pipe (AT host will be detached by transition) */
+	/* Attach CMUX to UART pipe */
 	ret = modem_cmux_attach(&cmux.instance, cmux.uart_pipe);
 	if (ret) {
 		LOG_ERR("Failed to attach CMUX to UART pipe. (%d)", ret);
+		/* Try to switch AT host back to UART so the error is reported correctly */
+		stop_work_fn(NULL);
 		return ret;
 	}
 


### PR DESCRIPTION
cmux_start() assigns cmux.uart_pipe before switching the AT host and attaching CMUX, but returned on failure of either step without clearing it. Since sm_cmux_is_started() reports purely on cmux.uart_pipe, a failed start left the module claiming to be started: a later AT#XCMUX would take the "resume" path and open a pipe that was never attached, and AT#XCMUXCLD would pass its guard and call modem_cmux_release() on an unattached instance.

Reset cmux.uart_pipe on both failure paths so the module reports its actual state.

This also addresses the cppcheck "condition is always true" report on the AT#XCMUXCLD guard, which stems from the same state variable.