### PR TITLE
sm_at_coap: guard against a data-mode callback with no staging buffer

### DIFF
--- a/app/src/sm_at_coap.c
+++ b/app/src/sm_at_coap.c
@@ -484,6 +484,12 @@ static int coap_datamode_callback(uint8_t op, const uint8_t *data, int len, uint
 			return -EINVAL;
 		}
 
+		if (req->staging == NULL) {
+			LOG_ERR("Data mode without a staging buffer");
+			exit_datamode_handler(sm_at_host_get_current(), -EINVAL);
+			return -EINVAL;
+		}
+
 		if (req->payload_len <= CONFIG_COAP_CLIENT_BLOCK_SIZE) {
 			/* Small payload: accumulate in staging[]; coap_start_request()
 			 * is called from DATAMODE_EXIT once all bytes are received.


### PR DESCRIPTION
Defensive NULL check on req->staging in coap_datamode_callback(). Both payload paths memcpy into that buffer unconditionally; it is only allocated when payload_len > 0, which is also the only case that enters data mode, so the check is not reachable today but removes the reliance on that invariant holding across future changes.

Re-verified the rest of the CoAP length handling flagged during review: parse_option_value() bounds both the hex and the text branch against out_max, the staging buffer is a fixed CONFIG_COAP_CLIENT_BLOCK_SIZE allocation rather than being sized from a peer-supplied length, and a negative <payload_len> is already rejected. No further change needed there.

CERT EXP34-C.