### PR TITLE
app: coap: Support CoAP Observe subscriptions

### DIFF
--- a/app/src/sm_at_coap.c
+++ b/app/src/sm_at_coap.c
@@ -81,6 +81,7 @@ struct coap_request {
 	struct k_sem staging_consumed;  /* Signaled: coap_client has consumed staging[] */
 	bool payload_aborted;           /* Set on data mode error; payload_cb returns -EIO */
 	atomic_t cancelled;             /* Set by AT#XCOAPCCANCEL */
+	bool observe;                   /* Observe register: keep alive across notifications */
 	/* Response tracking */
 	size_t bytes_sent;              /* Bytes delivered to host via URCs */
 	int status_code;                /* CoAP response code (or -1 on failure) */
@@ -275,12 +276,29 @@ static void coap_callback(const struct coap_client_response_data *data, void *us
 					return;
 				}
 			}
-		} else {
+		} else if (!atomic_get(&req->cancelled)) {
+			/* Suppress delivery of a notification that is already in flight
+			 * when AT#XCOAPCCANCEL sets the cancelled flag.
+			 */
 			coap_send_data(req, data->payload, data->payload_len);
 		}
 	}
 
 	if (data->last_block) {
+		if (req->observe && !atomic_get(&req->cancelled)) {
+			/* Observe notification fully delivered. coap_client keeps the
+			 * request active, so keep our state alive too and reset the
+			 * offset for the next notification. Teardown happens only on
+			 * AT#XCOAPCCANCEL or an error/failure result.
+			 *
+			 * Take coap_mutex: in manual receive mode AT#XCOAPCDATA
+			 * reads/updates bytes_sent under the same lock.
+			 */
+			k_mutex_lock(&coap_mutex, K_FOREVER);
+			req->bytes_sent = 0;
+			k_mutex_unlock(&coap_mutex);
+			return;
+		}
 		coap_finish_request(req);
 	}
 }
@@ -775,6 +793,17 @@ STATIC int handle_at_coap_req(enum at_parser_cmd_type cmd_type, struct at_parser
 			}
 			opt->len = (uint16_t)decoded_len;
 			req->num_extra_options++;
+
+			/* Observe register (value 0) turns this into a persistent
+			 * subscription; deregister (value 1) stays a one-shot request.
+			 * The value is an unsigned integer in network byte order, so
+			 * register is only an empty value or a single 0x00 byte.
+			 */
+			if (opt_num == COAP_OPTION_OBSERVE &&
+			    (decoded_len == 0 ||
+			     (decoded_len == 1 && opt->value[0] == 0))) {
+				req->observe = true;
+			}
 		}
 
 		if (payload_len > 0) {

--- a/doc/app/at_coap.rst
+++ b/doc/app/at_coap.rst
@@ -137,6 +137,14 @@ Syntax
      35,"coap://proxy/res"     Proxy-Uri verbatim string
      6,"0x00",17,"0x3c"        Observe register + Accept cbor
 
+.. note::
+
+   The Observe option (option ``6``) with the register value ``"0x00"`` starts a persistent subscription.
+   The request stays active and the firmware delivers each server notification through ``#XCOAPCDATA`` (automatic mode) or ``#XCOAPCHEAD`` (manual mode).
+   No ``#XCOAPCSTAT`` is emitted between notifications.
+   To stop the subscription, use ``AT#XCOAPCCANCEL``.
+   You cannot send a separate deregister request (``6,"0x01"``) while the subscription is active, because only one CoAP request can be active at a time.
+
 Unsolicited notification
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -290,7 +298,16 @@ CoAP GET with Observe and Accept options (option 6 = Observe register ``"0x00"``
    #XCOAPCDATA: 0,0,18
    <18 bytes CBOR>
 
-   #XCOAPCSTAT: 0,69,18
+   #XCOAPCDATA: 0,0,18
+   <18 bytes CBOR>
+
+   AT#XCOAPCCANCEL=0
+   OK
+
+   #XCOAPCSTAT: 0,-1,0
+
+The subscription stays active and delivers a ``#XCOAPCDATA`` notification for each server update until you cancel it with ``AT#XCOAPCCANCEL``.
+The ``#XCOAPCSTAT`` notification is emitted only when the subscription ends.
 
 Test command
 ------------
@@ -439,6 +456,7 @@ CoAP request cancel #XCOAPCCANCEL
 ==================================
 
 The ``#XCOAPCCANCEL`` command cancels the active CoAP request.
+It is also the mechanism for stopping a CoAP Observe subscription started with the Observe register option (``6,"0x00"``).
 
 Set command
 -----------


### PR DESCRIPTION
Keep the request alive across notifications when the Observe register option (opt 6, value 0x00) is present. Previously the request was torn down and #XCOAPCSTAT emitted after the first last_block callback, discarding all subsequent server notifications.

Use AT#XCOAPCCANCEL to stop the subscription; a deregister request (6,"0x01") is not supported while a subscription is active.

Jira: SM-257