### PR TITLE
Define SM_MAX_DNS_LEN and increase SM_MAX_URL

### DIFF
--- a/app/src/sm_at_fota.c
+++ b/app/src/sm_at_fota.c
@@ -5,6 +5,7 @@
  */
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <modem/nrf_modem_lib.h>
 #include <nrf_modem_delta_dfu.h>
 #include <zephyr/kernel.h>
@@ -203,9 +204,9 @@ static int do_fota_start(const char *file_uri, size_t file_uri_len, int sec_tag,
 	size_t path_off;
 
 	/* Safety free in case a terminal event was somehow missed. */
-	k_free(fota_hostname);
+	free(fota_hostname);
 	fota_hostname = NULL;
-	k_free(fota_path);
+	free(fota_path);
 	fota_path = NULL;
 
 	http_parser_url_init(&parser);
@@ -240,7 +241,7 @@ static int do_fota_start(const char *file_uri, size_t file_uri_len, int sec_tag,
 	}
 
 	/* host: scheme + authority (everything before the path), e.g. "https://host:port" */
-	fota_hostname = k_malloc(path_off + 1);
+	fota_hostname = malloc(path_off + 1);
 	if (!fota_hostname) {
 		return -ENOMEM;
 	}
@@ -248,9 +249,9 @@ static int do_fota_start(const char *file_uri, size_t file_uri_len, int sec_tag,
 	fota_hostname[path_off] = '\0';
 
 	/* path: URI content after the leading '/' */
-	fota_path = k_malloc(file_uri_len - path_off);
+	fota_path = malloc(file_uri_len - path_off);
 	if (!fota_path) {
-		k_free(fota_hostname);
+		free(fota_hostname);
 		fota_hostname = NULL;
 		return -ENOMEM;
 	}
@@ -275,9 +276,9 @@ static int do_fota_start(const char *file_uri, size_t file_uri_len, int sec_tag,
 
 	if (ret) {
 		/* Failed to start; fota_download won't fire a terminal event, so free now. */
-		k_free(fota_hostname);
+		free(fota_hostname);
 		fota_hostname = NULL;
-		k_free(fota_path);
+		free(fota_path);
 		fota_path = NULL;
 	}
 
@@ -302,9 +303,9 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 		break;
 	case FOTA_DOWNLOAD_EVT_FINISHED:
 		/* fota_download is done; release the URI buffers. */
-		k_free(fota_hostname);
+		free(fota_hostname);
 		fota_hostname = NULL;
-		k_free(fota_path);
+		free(fota_path);
 		fota_path = NULL;
 		sm_fota_stage = FOTA_STAGE_ACTIVATE;
 		sm_fota_info = 0;
@@ -329,9 +330,9 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 		break;
 	case FOTA_DOWNLOAD_EVT_ERROR:
 		/* fota_download is done; release the URI buffers. */
-		k_free(fota_hostname);
+		free(fota_hostname);
 		fota_hostname = NULL;
-		k_free(fota_path);
+		free(fota_path);
 		fota_path = NULL;
 		sm_fota_status = FOTA_STATUS_ERROR;
 		sm_fota_info = evt->cause;
@@ -342,9 +343,9 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 		break;
 	case FOTA_DOWNLOAD_EVT_CANCELLED:
 		/* fota_download is done; release the URI buffers. */
-		k_free(fota_hostname);
+		free(fota_hostname);
 		fota_hostname = NULL;
-		k_free(fota_path);
+		free(fota_path);
 		fota_path = NULL;
 		sm_fota_status = FOTA_STATUS_CANCELLED;
 		sm_fota_info = 0;

--- a/app/src/sm_at_icmp.c
+++ b/app/src/sm_at_icmp.c
@@ -522,8 +522,8 @@ STATIC int handle_at_icmp_ping(enum at_parser_cmd_type cmd_type, struct at_parse
 			       uint32_t param_count)
 {
 	int err = -EINVAL;
-	char target[SM_MAX_URL];
-	int size = SM_MAX_URL;
+	char target[SM_MAX_DNS_LEN + 1] = {0};
+	size_t size = sizeof(target);
 
 	switch (cmd_type) {
 	case AT_PARSER_CMD_TYPE_SET:

--- a/app/src/sm_at_mqtt.c
+++ b/app/src/sm_at_mqtt.c
@@ -49,7 +49,7 @@ static struct sm_mqtt_ctx {
 	struct modem_pipe *pipe;
 } ctx;
 
-static char mqtt_broker_url[SM_MAX_URL + 1];
+static char mqtt_broker_url[SM_MAX_DNS_LEN + 1];
 static uint16_t mqtt_broker_port;
 static char mqtt_clientid[MQTT_MAX_CID_LEN + 1];
 static char mqtt_username[SM_MAX_USERNAME + 1];

--- a/app/src/sm_at_socket.c
+++ b/app/src/sm_at_socket.c
@@ -59,7 +59,7 @@ enum sm_socket_send_result_mode {
 	AT_SOCKET_SEND_RESULT_NW_ACK_URC = 1 /* URC from network acknowledgment will follow. */
 };
 
-static char udp_url[SM_MAX_URL];
+static char udp_url[SM_MAX_DNS_LEN + 1];
 static uint16_t udp_port;
 
 struct sm_async_poll {
@@ -931,7 +931,7 @@ static int sec_sockopt_get(struct sm_socket *sock, enum at_sec_sockopt at_option
 			rsp_send("\r\n#XSSOCKETOPT: %d,0x%x\r\n", sock->fd, value);
 		}
 	} else if (level == SOL_TLS && option == TLS_HOSTNAME) {
-		char hostname[SM_MAX_URL] = {0};
+		char hostname[SM_MAX_DNS_LEN] = {0};
 
 		len = sizeof(hostname);
 		ret = zsock_getsockopt(sock->fd, level, option, &hostname, &len);
@@ -1629,8 +1629,8 @@ STATIC int handle_at_secure_socketopt(enum at_parser_cmd_type cmd_type,
 		}
 		if (op == AT_SOCKETOPT_SET) {
 			int value_int = 0;
-			char value_str[SM_MAX_URL] = {0};
-			int size = SM_MAX_URL;
+			char value_str[SM_MAX_DNS_LEN + 1] = {0};
+			size_t size = sizeof(value_str);
 
 			err = at_parser_num_get(parser, 4, &value_int);
 			if (err == -EOPNOTSUPP) {
@@ -1702,8 +1702,8 @@ STATIC int handle_at_connect(enum at_parser_cmd_type cmd_type, struct at_parser 
 {
 	int err = -EINVAL;
 	int fd;
-	char url[SM_MAX_URL] = {0};
-	int size = SM_MAX_URL;
+	char url[SM_MAX_DNS_LEN + 1] = {0};
+	size_t size = sizeof(url);
 	uint16_t port;
 	struct sm_socket *sock = NULL;
 
@@ -2192,8 +2192,8 @@ STATIC int handle_at_getaddrinfo(enum at_parser_cmd_type cmd_type, struct at_par
 {
 	int err = -EINVAL;
 	char hostname[NI_MAXHOST];
-	char host[SM_MAX_URL];
-	int size = SM_MAX_URL;
+	char host[SM_MAX_DNS_LEN + 1] = {0};
+	size_t size = sizeof(host);
 	struct zsock_addrinfo *result;
 	struct zsock_addrinfo *res;
 	char rsp_buf[256];

--- a/app/src/sm_defines.h
+++ b/app/src/sm_defines.h
@@ -25,9 +25,10 @@ enum {
 /** The maximum allowed length of data send/receive through the Serial Modem */
 #define SM_MAX_MESSAGE_SIZE 2048
 
-#define SM_MAX_URL          128  /** max size of URL string */
+#define SM_MAX_DNS_LEN      128  /** max size of DNS name */
 #define SM_MAX_USERNAME     32   /** max size of username in login */
 #define SM_MAX_PASSWORD     32   /** max size of password in login */
+#define SM_MAX_URL          SM_AT_MAX_CMD_LEN  /** max size of URL string */
 
 #define SM_SYNC_STR     "Ready\r\n"
 #define SM_SYNC_ERR_STR "INIT ERROR\r\n"


### PR DESCRIPTION
## app: Define SM_MAX_DNS_LEN and increase SM_MAX_URL 

All existing users of SM_MAX_URL are now refactored to
use SM_MAX_DNS_LEN when the operation is only meant to
be a DNS name.

SM_MAX_URL increased to SM_AT_MAX_CMD_LEN (4kB) for FOTA


## app: Use malloc()/free() on FOTA module 

Instead of using system heap, use the C library's malloc/free
