### PR TITLE
scripts: Do not deadblock when USB is removed

### DIFF
--- a/app/scripts/sm2_start_cmux.sh
+++ b/app/scripts/sm2_start_cmux.sh
@@ -107,7 +107,7 @@ cleanup() {
 trap cleanup ERR
 
 # Configure serial port
-stty -F $MODEM $BAUD pass8 raw crtscts clocal
+stty -F $MODEM $BAUD pass8 raw crtscts clocal -hupcl
 
 log_dbg "Wait modem to boot"
 if chat -t1 "Ready--" "AT" "OK" <$MODEM >$MODEM; then
@@ -125,7 +125,7 @@ if [ $IPR_BAUD -ne 0 ]; then
 	log_dbg "Set baud rate on modem to $IPR_BAUD"
 	chat $CHATOPT -t1 '' "AT+IPR=$IPR_BAUD" "OK" >$MODEM <$MODEM
 	# Reconfigure serial port
-	stty -F $MODEM $IPR_BAUD pass8 raw crtscts clocal
+	stty -F $MODEM $IPR_BAUD pass8 raw crtscts clocal -hupcl
 fi
 
 log_dbg "Attach CMUX channel to modem..."
@@ -158,18 +158,20 @@ check_devices_or_exit
 echo "DLC 1 (PPP):       $DLC1"
 echo "DLC 2 (AT):        $DLC2"
 
-stty -F $DLC1 clocal
+stty -F $DLC1 clocal -hupcl
+stty -F $DLC2 clocal -hupcl
 
 if [ $TRACE -gt 0 ]; then
 	echo "DLC 3 (TRACE):        $DLC3"
 	echo "Starting trace collection to $MODEM_TRACE_FILE"
-	stty -F $DLC3 raw clocal -icrnl -ixon -opost
+	stty -F $DLC3 raw clocal -icrnl -ixon -opost -hupcl
 	chat $CHATOPT -t1 '' 'AT#XCMUXTRACE=3' 'OK' >$DLC1 <$DLC1
 
 	# Prefer to use socat, if installed.
 	if command -v socat >/dev/null 2>&1; then
 		start-stop-daemon --start --pidfile $TRACE_PID_FILE --make-pidfile \
-			--background --exec $(command -v socat) -- -u $DLC3,cfmakeraw,clocal=1 \
+			--background --exec $(command -v socat) -- \
+			-u $DLC3,cfmakeraw,clocal=1,hupcl=0 \
 			CREATE:$MODEM_TRACE_FILE
 	else
 		start-stop-daemon --start --pidfile $TRACE_PID_FILE --make-pidfile \

--- a/app/scripts/sm2_start_ppp.sh
+++ b/app/scripts/sm2_start_ppp.sh
@@ -212,7 +212,7 @@ trap cleanup ERR
 
 if [ $CMUX_ATTACHED -eq 0 ]; then
 	# Configure serial port
-	stty -F $MODEM $BAUD pass8 raw crtscts clocal
+	stty -F $MODEM $BAUD pass8 raw crtscts clocal -hupcl
 
 	log_dbg "Wait modem to boot"
 	if chat -t1 "Ready--" "AT" "OK" <$MODEM >$MODEM; then
@@ -230,7 +230,7 @@ if [ $CMUX_ATTACHED -eq 0 ]; then
 		log_dbg "Set baud rate on modem to $IPR_BAUD"
 		chat $CHATOPT -t1 '' "AT+IPR=$IPR_BAUD" "OK" >$MODEM <$MODEM
 		# Reconfigure serial port
-		stty -F $MODEM $IPR_BAUD pass8 raw crtscts clocal
+		stty -F $MODEM $IPR_BAUD pass8 raw crtscts clocal -hupcl
 	fi
 
 	log_dbg "Attach CMUX channel to modem..."
@@ -264,18 +264,20 @@ check_devices_or_exit
 log_inf "DLC 1 (PPP):       $DLC1"
 log_inf "DLC 2 (AT):        $DLC2"
 
-stty -F $DLC1 clocal
+stty -F $DLC1 clocal -hupcl
+stty -F $DLC2 clocal -hupcl
 
 if [ $TRACE -gt 0 ]; then
-	log_inf "DLC 3 (TRACE):     $DLC3"
-	log_inf "Starting trace collection to $MODEM_TRACE_FILE"
-	stty -F $DLC3 raw clocal -icrnl -ixon -opost
+	echo "DLC 3 (TRACE):        $DLC3"
+	echo "Starting trace collection to $MODEM_TRACE_FILE"
+	stty -F $DLC3 raw clocal -icrnl -ixon -opost -hupcl
 	chat $CHATOPT -t1 '' 'AT#XCMUXTRACE=3' 'OK' >$DLC1 <$DLC1
 
 	# Prefer to use socat, if installed.
 	if command -v socat >/dev/null 2>&1; then
 		start-stop-daemon --start --pidfile $TRACE_PID_FILE --make-pidfile \
-			--background --exec $(command -v socat) -- -u $DLC3,cfmakeraw,clocal=1 \
+			--background --exec $(command -v socat) -- \
+			-u $DLC3,cfmakeraw,clocal=1,hupcl=0 \
 			CREATE:$MODEM_TRACE_FILE
 	else
 		start-stop-daemon --start --pidfile $TRACE_PID_FILE --make-pidfile \
@@ -339,6 +341,8 @@ export -f shutdown_modem
 export -f cmux_close
 export -f stop_trace
 export -f check_devices_or_exit
+export -f log_inf
+export -f log_dbg
 
 log_inf "Connect and wait for PPP link..."
 

--- a/app/scripts/sm2_stop_cmux.sh
+++ b/app/scripts/sm2_stop_cmux.sh
@@ -77,12 +77,12 @@ cmux_close() {
 }
 
 # If channel is still open, force-close with raw CMUX CLD frame
-if [ $CHAT_ERR -ne 0 ]; then
+if [ $CHAT_ERR -ne 0 ] && [ -c "$MODEM" ]; then
 	log_dbg "Force-closing CMUX with raw CLD frame..."
 	cmux_close
 fi
 
-if [ $IPR_BAUD -ne 0 ]; then
+if [ $IPR_BAUD -ne 0 ] && [ -c "$MODEM" ]; then
 	log_dbg "Restoring baud rate on modem to $IPR_BAUD"
 	stty -F $MODEM $BAUD
 	chat $CHATOPT -t1 '' "AT+IPR=$IPR_BAUD" "OK" >$MODEM <$MODEM || true

--- a/app/scripts/sm_start_ppp.sh
+++ b/app/scripts/sm_start_ppp.sh
@@ -202,7 +202,7 @@ cleanup() {
 trap cleanup ERR
 
 # Configure serial port
-stty -F $MODEM $BAUD pass8 raw crtscts clocal
+stty -F $MODEM $BAUD pass8 raw crtscts clocal -hupcl
 
 log_dbg "Wait modem to boot"
 if chat -t1 "Ready--" "AT" "OK" <$MODEM >$MODEM; then
@@ -221,7 +221,7 @@ if [ $IPR_BAUD -ne 0 ]; then
 	log_dbg "Set baud rate on modem to $IPR_BAUD"
 	chat $CHATOPT -t1 '' "AT+IPR=$IPR_BAUD" "OK" >$MODEM <$MODEM
 	# Reconfigure serial port
-	stty -F $MODEM $IPR_BAUD pass8 raw crtscts clocal
+	stty -F $MODEM $IPR_BAUD pass8 raw crtscts clocal -hupcl
 fi
 
 log_dbg "Attach CMUX channel to modem..."
@@ -237,11 +237,12 @@ if [ $TRACE -gt 0 ]; then
 	MT_CMUX=$(ls /dev/gsmtty* | sort -V | head -n 3 | tail -n 1)
 	log_inf "DLC 3 (TRACE):     $MT_CMUX"
 	log_inf "Starting trace collection to $MODEM_TRACE_FILE"
-	stty -F $MT_CMUX raw clocal -icrnl -ixon -opost
+	stty -F $MT_CMUX raw clocal -icrnl -ixon -opost -hupcl
 fi
 sleep 3
 
-stty -F $AT_CMUX clocal
+stty -F $AT_CMUX clocal -hupcl
+stty -F $PPP_CMUX clocal -hupcl
 test -c $AT_CMUX
 
 if [ $TRACE -gt 0 ]; then
@@ -249,7 +250,8 @@ if [ $TRACE -gt 0 ]; then
 	# Prefer to use socat, if installed.
 	if command -v socat >/dev/null 2>&1; then
 		start-stop-daemon --start --pidfile $TRACE_PID_FILE --make-pidfile \
-			--background --exec $(command -v socat) -- -u $MT_CMUX,cfmakeraw,clocal=1 \
+			--background --exec $(command -v socat) -- \
+			-u $MT_CMUX,cfmakeraw,clocal=1,hupcl=0 \
 			CREATE:$MODEM_TRACE_FILE
 	else
 		start-stop-daemon --start --pidfile $TRACE_PID_FILE --make-pidfile \
@@ -320,6 +322,8 @@ export -f ppp_start
 export -f shutdown_modem
 export -f cmux_close
 export -f check_devices_or_exit
+export -f log_inf
+export -f log_dbg
 
 # Start PPPD in a subshell
 # Logs go to syslog so redirect output to /dev/null


### PR DESCRIPTION
Set -HUPCL flag for every serial port that we use.

See man stty:
*        [-]hup send a hangup signal when the last process closes the tty

This allows USB serial port to be removed without the in-kernel n_gsm driver to be deadblocking forever when trying to send modem control signals to removed tty port.

Also: few minor fixes:
* Verify /dev/ttyACM0 exist before writing CMUX close down message
* Export log_dbg() and log_inf() so background jobs log correctly to syslog