### PR TITLE
workflows: Fix PR memory report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
   build-and-test-in-toolchain-bundle:
     permissions:
       contents: read
-      pull-requests: write
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Serial Modem repository
@@ -96,27 +95,28 @@ jobs:
           echo "PR_HEAD_BUILD_LOG=$log" >> "$GITHUB_ENV"
           echo "CI_RUN_URL=$run_url" >> "$GITHUB_ENV"
 
-      - name: Generate nRF91M1 app-size diff
+      - name: Generate nRF91M1 memory diff
         if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BOARD: nrf9151dk/nrf9151/ns
           SCENARIO: serial_modem.nrf91m1
-          SIZE_COMMENT_PATH: ${{ github.workspace }}/size-comment.md
+          MEMORY_REPORT_PATH: ${{ github.workspace }}/memory-report.md
         run: |
-          ./nrfutil toolchain-manager launch -- bash serial_modem/scripts/pr-size-diff.sh
+          ./nrfutil toolchain-manager launch -- bash serial_modem/scripts/pr-mem-diff.sh
 
-      - name: Post sticky size comment
-        # Posting needs pull-requests: write, which the default GITHUB_TOKEN
-        # does not grant on PRs from forks. Don't fail the build when the
-        # comment can't be posted (e.g. fork PRs); the size report is still
-        # available in the job log / artifacts.
+      - name: Save PR number for comment workflow
         if: github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@v2
+        run: echo "${{ github.event.pull_request.number }}" > ${{ github.workspace }}/pr-number.txt
+
+      - name: Upload memory report artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          header: nrf91m1-app-size
-          path: ${{ github.workspace }}/size-comment.md
+          name: memory-report
+          path: |
+            ${{ github.workspace }}/memory-report.md
+            ${{ github.workspace }}/pr-number.txt
 
       - name: Build Serial Modem nightly
         if: ${{ github.event_name == 'schedule' || inputs.trigger_source == 'release-workflow' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/post-memory-report.yml
+++ b/.github/workflows/post-memory-report.yml
@@ -1,0 +1,34 @@
+name: Post Memory Report
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+jobs:
+  post-comment:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download memory report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: memory-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Post memory report comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: nrf91m1-app-memory-report
+          number: ${{ steps.pr.outputs.number }}
+          path: memory-report.md

--- a/scripts/pr-mem-diff.sh
+++ b/scripts/pr-mem-diff.sh
@@ -2,13 +2,13 @@
 # Generate a sticky-comment-ready markdown body comparing the PR HEAD app
 # image against its merge base
 #
-# Required env vars: PR_HEAD_ELF PR_HEAD_BUILD_LOG BASE_SHA BOARD SIZE_COMMENT_PATH
+# Required env vars: PR_HEAD_ELF PR_HEAD_BUILD_LOG BASE_SHA BOARD MEMORY_REPORT_PATH
 #   PR_HEAD_ELF and PR_HEAD_BUILD_LOG are relative to the west workspace dir
 #   (parent of this checkout). PR_HEAD_BUILD_LOG is the per-scenario Twister
 #   build.log (it carries the "Memory region" table flash%/ram% are read from).
 # Optional env vars:
 #   CI_RUN_URL   Link to the CI run, embedded in the comment.
-#   SCENARIO     Twister scenario to size (default: serial_modem.nrf91m1).
+#   SCENARIO     Twister scenario for memory report (default: serial_modem.nrf91m1).
 #   TWISTER_ROOT Twister testsuite root, relative to the repo (default: app).
 #
 # The baseline is built the same way CI builds the PR: a single Twister
@@ -16,20 +16,20 @@
 # and the diff reflects code changes, not config drift.
 
 set -euo pipefail
-: "${PR_HEAD_ELF:?}" "${PR_HEAD_BUILD_LOG:?}" "${BASE_SHA:?}" "${BOARD:?}" "${SIZE_COMMENT_PATH:?}"
+: "${PR_HEAD_ELF:?}" "${PR_HEAD_BUILD_LOG:?}" "${BASE_SHA:?}" "${BOARD:?}" "${MEMORY_REPORT_PATH:?}"
 SCENARIO="${SCENARIO:-serial_modem.nrf91m1}"
 TWISTER_ROOT="${TWISTER_ROOT:-app}"
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"       # serial_modem/
 WORKSPACE_DIR="$(cd "$REPO_ROOT/.." && pwd)"        # west workspace
-SIZE_DIR="$WORKSPACE_DIR/artifacts/size"
-mkdir -p "$SIZE_DIR" "$(dirname "$SIZE_COMMENT_PATH")"
+MEMORY_REPORT_DIR="$WORKSPACE_DIR/artifacts/size"
+mkdir -p "$MEMORY_REPORT_DIR" "$(dirname "$MEMORY_REPORT_PATH")"
 
 PR_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD)
 
 if ! command -v size >/dev/null 2>&1; then
-  echo "App size report unavailable: 'size' (binutils) not found on PATH." \
-       "See [CI run](${CI_RUN_URL:-})" > "$SIZE_COMMENT_PATH"
+  echo "App memory report unavailable: 'size' (binutils) not found on PATH." \
+       "See [CI run](${CI_RUN_URL:-})" > "$MEMORY_REPORT_PATH"
   exit 0
 fi
 
@@ -80,7 +80,7 @@ restore_pr_checkout() {
 report_failed() {
   trap - ERR EXIT
   restore_pr_checkout
-  echo "App size report failed. See [CI run](${CI_RUN_URL:-})" > "$SIZE_COMMENT_PATH"
+  echo "App memory report failed. See [CI run](${CI_RUN_URL:-})" > "$MEMORY_REPORT_PATH"
   exit 0
 }
 
@@ -89,11 +89,11 @@ trap restore_pr_checkout EXIT
 
 PR_ELF="$WORKSPACE_DIR/$PR_HEAD_ELF"
 PR_LOG="$WORKSPACE_DIR/$PR_HEAD_BUILD_LOG"
-BASELINE_OUT="$SIZE_DIR/twister-baseline"
+BASELINE_OUT="$MEMORY_REPORT_DIR/twister-baseline"
 
 [ -f "$PR_ELF" ] && [ -f "$PR_LOG" ] || report_failed
-size_report "$PR_ELF" "$PR_LOG" > "$SIZE_DIR/pr.size"
-require_size_file "$SIZE_DIR/pr.size" || report_failed
+size_report "$PR_ELF" "$PR_LOG" > "$MEMORY_REPORT_DIR/pr.size"
+require_size_file "$MEMORY_REPORT_DIR/pr.size" || report_failed
 
 git -C "$REPO_ROOT" fetch --depth=1 origin "$BASE_SHA"
 git -C "$REPO_ROOT" checkout --detach "$BASE_SHA"
@@ -104,23 +104,24 @@ git -C "$REPO_ROOT" checkout --detach "$BASE_SHA"
 BASELINE_ELF="$(find "$BASELINE_OUT" -type f -path "*/$SCENARIO/app/zephyr/zephyr.elf" | head -n1)"
 BASELINE_LOG="$(find "$BASELINE_OUT" -type f -path "*/$SCENARIO/build.log" | head -n1)"
 [ -n "$BASELINE_ELF" ] && [ -f "$BASELINE_ELF" ] || report_failed
-size_report "$BASELINE_ELF" "$BASELINE_LOG" > "$SIZE_DIR/baseline.size"
-require_size_file "$SIZE_DIR/baseline.size" || report_failed
+size_report "$BASELINE_ELF" "$BASELINE_LOG" > "$MEMORY_REPORT_DIR/baseline.size"
+require_size_file "$MEMORY_REPORT_DIR/baseline.size" || report_failed
 
 restore_pr_checkout
 trap - ERR EXIT
 
 diff -u0 --label baseline --label pr \
-  "$SIZE_DIR/baseline.size" "$SIZE_DIR/pr.size" \
-  > "$SIZE_DIR/size_change.diff" || true
-if [ -s "$SIZE_DIR/size_change.diff" ]; then
+  "$MEMORY_REPORT_DIR/baseline.size" "$MEMORY_REPORT_DIR/pr.size" \
+  > "$MEMORY_REPORT_DIR/size_change.diff" || true
+if [ -s "$MEMORY_REPORT_DIR/size_change.diff" ]; then
   {
-    echo "App size changed. See [CI run](${CI_RUN_URL:-})"
+    echo "Memory usage changed for nRF91M1 configuration. See [CI run](${CI_RUN_URL:-})"
     echo '```diff'
-    printf ' '; head -n 1 "$SIZE_DIR/baseline.size"
-    cat "$SIZE_DIR/size_change.diff"
+    printf ' '; head -n 1 "$MEMORY_REPORT_DIR/baseline.size"
+    cat "$MEMORY_REPORT_DIR/size_change.diff"
     echo '```'
-  } > "$SIZE_COMMENT_PATH"
+  } > "$MEMORY_REPORT_PATH"
 else
-  echo "App size did not change. See [CI run](${CI_RUN_URL:-})" > "$SIZE_COMMENT_PATH"
+  echo "Memory usage did not change for nRF91M1 configuration. See [CI run](${CI_RUN_URL:-})" \
+    > "$MEMORY_REPORT_PATH"
 fi


### PR DESCRIPTION
Fixing memory delta reports for PRs.

An example report looks as follows from here: https://github.com/trantanen/ncs-serial-modem/pull/13#issuecomment-5280185759

> App size changed. See [CI run](https://github.com/trantanen/ncs-serial-modem/actions/runs/31694854362)
> 
> ```diff
>        text       data        bss        dec        hex     flash%       ram%
> --- baseline
> +++ pr
> @@ -2 +2 @@
> -    319404      74516     170370     564290      89c42     95.26%     83.55%
> +    319036      74100     170370     563506      89932     95.07%     83.55%
> ```