### PR TITLE
scripts: Fix potential issues on Linux PPP/CMUX scripts

### DIFF
--- a/app/scripts/sm2_start_cmux.sh
+++ b/app/scripts/sm2_start_cmux.sh
@@ -89,10 +89,19 @@ if pgrep ldattach >/dev/null; then
 	exit 1
 fi
 
+# Remove non "character special" files from /dev/gsmtty*
+# These might be a residue from bug in the script.
+# For example: 'chat PARAMS... >/dev/gsmtty1 </dev/gsmtty1' after device disappeared
+if [[ -n $(find /dev -name 'gsmtty*' -print -delete) ]]; then
+	echo "Warning: invalid CMUX devices found (/dev/gsmtty*), removed"
+fi
+
 cmux_close() {
-	printf "\xF9\xF9\xF9\xF9\xF9\xF9\xF9\xF9" > $MODEM
-	printf "\xF9\x03\xEF\x05\xC3\x01\xF2\xF9" > $MODEM
-	sleep 2
+	if [[ -c $MODEM ]]; then
+		printf "\xF9\xF9\xF9\xF9\xF9\xF9\xF9\xF9" > $MODEM
+		printf "\xF9\x03\xEF\x05\xC3\x01\xF2\xF9" > $MODEM
+		sleep 2
+	fi
 }
 
 cleanup() {
@@ -131,7 +140,9 @@ fi
 log_dbg "Attach CMUX channel to modem..."
 chat $CHATOPT -t1 '' "AT+CMUX=0" "OK" >$MODEM <$MODEM
 ldattach GSM0710 $MODEM
+log_dbg "Wait for CMUX to open"
 sleep 3
+log_dbg "continue"
 
 # DLC 1: PPP data channel
 # DLC 2: AT command channel for host
@@ -158,8 +169,8 @@ check_devices_or_exit
 echo "DLC 1 (PPP):       $DLC1"
 echo "DLC 2 (AT):        $DLC2"
 
-stty -F $DLC1 clocal -hupcl
-stty -F $DLC2 clocal -hupcl
+stty -F $DLC1 clocal
+stty -F $DLC2 clocal
 
 if [ $TRACE -gt 0 ]; then
 	echo "DLC 3 (TRACE):        $DLC3"

--- a/app/scripts/sm2_start_ppp.sh
+++ b/app/scripts/sm2_start_ppp.sh
@@ -176,6 +176,13 @@ if [ $CMUX_ATTACHED -eq 0 ]; then
 		log_inf "Error: existing ldattach process found"
 		exit 1
 	fi
+
+	# Remove non "character special" files from /dev/gsmtty*
+	# These might be a residue from bug in the script.
+	# For example: 'chat PARAMS... >/dev/gsmtty1 </dev/gsmtty1' after device disappeared
+	if [[ -n $(find /dev -name 'gsmtty*' -print -delete) ]]; then
+		log_inf "Warning: invalid CMUX devices found (/dev/gsmtty*), removed"
+	fi
 else
 	if ! find /dev -type c -name 'gsmtty*' | grep -q . ; then
 		log_inf "Error: no CMUX devices found (/dev/gsmtty*). Run sm2_start_cmux.sh first."
@@ -184,9 +191,11 @@ else
 fi
 
 cmux_close() {
-	printf "\xF9\xF9\xF9\xF9\xF9\xF9\xF9\xF9" > $MODEM
-	printf "\xF9\x03\xEF\x05\xC3\x01\xF2\xF9" > $MODEM
-	sleep 2
+	if [[ -c $MODEM ]]; then
+		printf "\xF9\xF9\xF9\xF9\xF9\xF9\xF9\xF9" > $MODEM
+		printf "\xF9\x03\xEF\x05\xC3\x01\xF2\xF9" > $MODEM
+		sleep 2
+	fi
 }
 
 stop_trace() {
@@ -236,7 +245,9 @@ if [ $CMUX_ATTACHED -eq 0 ]; then
 	log_dbg "Attach CMUX channel to modem..."
 	chat $CHATOPT -t1 '' "AT+CMUX=0" "OK" >$MODEM <$MODEM
 	ldattach GSM0710 $MODEM
+	log_dbg "Wait for CMUX to open"
 	sleep 3
+	log_dbg "continue"
 fi
 
 # DLC 1: PPP data channel
@@ -264,8 +275,8 @@ check_devices_or_exit
 log_inf "DLC 1 (PPP):       $DLC1"
 log_inf "DLC 2 (AT):        $DLC2"
 
-stty -F $DLC1 clocal -hupcl
-stty -F $DLC2 clocal -hupcl
+stty -F $DLC1 clocal
+stty -F $DLC2 clocal
 
 if [ $TRACE -gt 0 ]; then
 	echo "DLC 3 (TRACE):        $DLC3"
@@ -297,11 +308,11 @@ shutdown_modem() {
 		pkill ldattach
 	fi
 	sleep 1
-	if [ "$CHAT_ERR" -ne 0 ]; then
+	if [[ "$CHAT_ERR" -ne 0 && -c $MODEM ]]; then
 		cmux_close
 		chat $CHATOPT -t5 '' $SHUTDOWN_SCRIPT >$MODEM <$MODEM
 	fi
-	if [ $IPR_BAUD -ne 0 ]; then
+	if [[ $IPR_BAUD -ne 0 && -c $MODEM ]]; then
 		# Restore baud rate on modem
 		chat $CHATOPT -t1 '' "AT+IPR=$BAUD" "OK" >$MODEM <$MODEM
 		stty -F $MODEM $BAUD
@@ -322,8 +333,10 @@ ppp_start() {
 	test -O $PIDFILE && rm -f $PIDFILE
 }
 
-export DLC1
 export CMUX_ATTACHED
+export DLC1
+export DLC2
+export DLC3
 export MODEM
 export SHUTDOWN_SCRIPT
 export PPP_OPTIONS

--- a/app/scripts/sm_start_ppp.sh
+++ b/app/scripts/sm_start_ppp.sh
@@ -178,15 +178,24 @@ if find /dev -type c -name 'gsmtty*' | grep -q . ; then
 	exit 1
 fi
 
+# Remove non "character special" files from /dev/gsmtty*
+# These might be a residue from bug in the script.
+# For example: 'chat PARAMS... >/dev/gsmtty1 </dev/gsmtty1' after device disappeared
+if [[ -n $(find /dev -name 'gsmtty*' -print -delete) ]]; then
+	log_inf "Warning: invalid CMUX devices found (/dev/gsmtty*), removed"
+fi
+
 if pgrep ldattach >/dev/null; then
 	log_inf "Error: existing ldattach process found"
 	exit 1
 fi
 
 cmux_close() {
-	printf "\xF9\xF9\xF9\xF9\xF9\xF9\xF9\xF9" > $MODEM
-	printf "\xF9\x03\xEF\x05\xC3\x01\xF2\xF9" > $MODEM
-	sleep 2
+	if [[ -c $MODEM ]]; then
+		printf "\xF9\xF9\xF9\xF9\xF9\xF9\xF9\xF9" > $MODEM
+		printf "\xF9\x03\xEF\x05\xC3\x01\xF2\xF9" > $MODEM
+		sleep 2
+	fi
 }
 
 cleanup() {
@@ -194,7 +203,7 @@ cleanup() {
 	start-stop-daemon --stop --pidfile $TRACE_PID_FILE --remove-pidfile --oknodo
 	pkill pppd
 	pkill ldattach
-	printf "\xF9\x03\xEF\x05\xC3\x01\xF2\xF9" > $MODEM
+	cmux_close
 	log_inf "Failed to start..."
 	exit 1
 }
@@ -225,7 +234,12 @@ if [ $IPR_BAUD -ne 0 ]; then
 fi
 
 log_dbg "Attach CMUX channel to modem..."
-ldattach -c $'\rAT#XCMUX=1\r' GSM0710 $MODEM
+chat $CHATOPT -t1 '' "AT#XCMUX=1" "OK" >$MODEM <$MODEM
+ldattach GSM0710 $MODEM
+
+log_dbg "Wait for CMUX to open"
+sleep 3
+log_dbg "continue"
 
 AT_CMUX=$(ls /dev/gsmtty* | sort -V | head -n 1)
 PPP_CMUX=$(ls /dev/gsmtty* | sort -V | head -n 2 | tail -n 1)
@@ -237,13 +251,12 @@ if [ $TRACE -gt 0 ]; then
 	MT_CMUX=$(ls /dev/gsmtty* | sort -V | head -n 3 | tail -n 1)
 	log_inf "DLC 3 (TRACE):     $MT_CMUX"
 	log_inf "Starting trace collection to $MODEM_TRACE_FILE"
-	stty -F $MT_CMUX raw clocal -icrnl -ixon -opost -hupcl
+	stty -F "$MT_CMUX" raw clocal -icrnl -ixon -opost -hupcl
 fi
-sleep 3
 
-stty -F $AT_CMUX clocal -hupcl
-stty -F $PPP_CMUX clocal -hupcl
-test -c $AT_CMUX
+test -c "$AT_CMUX"
+test -c "$PPP_CMUX"
+stty -F "$AT_CMUX" clocal
 
 if [ $TRACE -gt 0 ]; then
 	log_inf "Starting trace collection..."
@@ -258,9 +271,6 @@ if [ $TRACE -gt 0 ]; then
 		--background --exec /bin/dd -- if=$MT_CMUX of=$MODEM_TRACE_FILE bs=1024
 	fi
 fi
-log_inf "Connect and wait for PPP link..."
-
-chat $CHATOPT -t$TIMEOUT "${CHAT_SCRIPT[@]}" >$AT_CMUX <$AT_CMUX
 
 check_devices_or_exit() {
 	# Verify that UART devices are still present
@@ -272,6 +282,10 @@ check_devices_or_exit() {
 		exit 1
 	fi
 }
+
+check_devices_or_exit
+log_inf "Connect and wait for PPP link..."
+chat $CHATOPT -t$TIMEOUT "${CHAT_SCRIPT[@]}" >$AT_CMUX <$AT_CMUX
 
 shutdown_modem() {
 	set +eu


### PR DESCRIPTION
* Ensure that 3 second sleep is done when waiting for CMUX to attach
* On few cases, output is written to >$MODEM without checking if that device exist and is a character special device
* check_devices_or_exit() refers to DLC1, DLC2 and DLC3 but only DLC1 was exported as environment variable.