### PR TITLE
app: memfault: Add custom trace event

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -39,5 +39,6 @@ target_sources_ifdef(CONFIG_NRF_PROVISIONING app PRIVATE src/sm_at_provisioning.
 add_subdirectory_ifdef(CONFIG_SM_CARRIER src/lwm2m_carrier)
 
 zephyr_include_directories(src)
+zephyr_include_directories(memfault)
 
 include(cmake/sm_version.cmake)

--- a/app/memfault/memfault_trace_reason_user_config.def
+++ b/app/memfault/memfault_trace_reason_user_config.def
@@ -1,0 +1,1 @@
+MEMFAULT_TRACE_REASON_DEFINE(modem_fault)

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -13,6 +13,9 @@
 #include <zephyr/sys/reboot.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <net/fota_download.h>
+#if defined(CONFIG_MEMFAULT)
+#include <memfault/core/trace_event.h>
+#endif /* CONFIG_MEMFAULT */
 #include "sm_at_host.h"
 #include "sm_at_dfu.h"
 #include "sm_at_fota.h"
@@ -51,6 +54,11 @@ static void on_modem_failure(struct k_work *)
 	int ret;
 	struct modem_pipe *pipe = sm_at_host_get_urc_pipe();
 
+#if defined(CONFIG_MEMFAULT)
+	/* Record the modem fault as a Memfault trace event */
+	MEMFAULT_TRACE_EVENT_WITH_LOG(modem_fault, "Modem fault: reason=0x%x pc=0x%x",
+				      modem_fault_info.reason, modem_fault_info.program_counter);
+#endif /* CONFIG_MEMFAULT */
 	urc_send_to(pipe, "\r\n#XMODEM: FAULT,0x%x,0x%x\r\n", modem_fault_info.reason,
 		    modem_fault_info.program_counter);
 


### PR DESCRIPTION
Add a user configuration file for custom trace events and define the "modem_fault" trace event, allowing modem faults to be reported to Memfault.