### PR TITLE
manifest: Update NCS 20260826 v3.4-branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,7 +13,7 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: 71aa8268dd56ed7672d045311f27912217068f19
+      revision: 3ce0b693bf73d6072a31918f45c8d1d3fa438854
       import:
         name-allowlist:
           - cjson


### PR DESCRIPTION
Take the latest NCS v3.4-branch to get Zephyr upmerge, which included Zephyr v4.4.2 and TF-M v2.3.1.