### PR TITLE
doc: Fix some Kconfig references

### DIFF
--- a/doc/app/at_generic.rst
+++ b/doc/app/at_generic.rst
@@ -771,7 +771,7 @@ These commands will print the following output in the log:
    [00:00:36.271,057] <inf> sm_at:   allocated:           0
    [00:00:36.271,057] <inf> sm_at:   max. allocated:   1280
 
-The output appears as follows when ``CONFIG_SM_DEBUG_STATS_THREAD_STACK`` and ``CONFIG_SYS_HEAP_INFO`` Kconfig options are enabled.
+The output appears as follows when :ref:`CONFIG_SM_DEBUG_STATS_THREAD_STACK <CONFIG_SM_DEBUG_STATS_THREAD_STACK>` and ``CONFIG_SYS_HEAP_INFO`` Kconfig options are enabled.
 ::
 
    [00:01:16.852,478] <inf> sm_at: System heap stats:

--- a/doc/app/at_sms.rst
+++ b/doc/app/at_sms.rst
@@ -11,7 +11,7 @@ This page describes SMS-related AT commands.
 
 .. note::
 
-   |SM|'s SMS implementation is based on the :ref:`lib_sms_readme` library, which uses the following AT commands: ``AT+CMGS``, ``AT+CNMI``, ``AT+CNMA``.
+   |SM|'s SMS implementation is based on the `SMS`_ library, which uses the following AT commands: ``AT+CMGS``, ``AT+CNMI``, ``AT+CNMA``.
    These modem AT commands should not be used in conjunction with the ``#XSMS`` command by the host in order to avoid unexpected behavior.
    The implementation always acknowledges incoming ``+CMT`` and ``+CDS`` notifications with ``AT+CNMA`` command.
 

--- a/doc/app/sm_configuration.rst
+++ b/doc/app/sm_configuration.rst
@@ -108,14 +108,14 @@ CONFIG_SM_AUTO_CONNECT - Connect to the network at start-up or reset
       CONFIG_SM_AUTO_CONNECT_PDN_USERNAME - PDN authentication username
          This option specifies the username to use for PDN authentication during automatic network attach.
          Do not set the Kconfig option (default) if no username is required.
-         Use only when ``CONFIG_SM_AUTO_CONNECT_PDN_AUTH`` is set to 1 (PAP) or 2 (CHAP).
+         Use only when :ref:`CONFIG_SM_AUTO_CONNECT_PDN_AUTH <CONFIG_SM_AUTO_CONNECT_PDN_AUTH>` is set to 1 (PAP) or 2 (CHAP).
 
       .. _CONFIG_SM_AUTO_CONNECT_PDN_PASSWORD:
 
       CONFIG_SM_AUTO_CONNECT_PDN_PASSWORD - PDN authentication password
          This option specifies the password to use for PDN authentication during automatic network attach.
          Leave empty (default) if no password is required.
-         Use only when ``CONFIG_SM_AUTO_CONNECT_PDN_AUTH`` is set to 1 (PAP) or 2 (CHAP).
+         Use only when :ref:`CONFIG_SM_AUTO_CONNECT_PDN_AUTH <CONFIG_SM_AUTO_CONNECT_PDN_AUTH>` is set to 1 (PAP) or 2 (CHAP).
 
    Example configuration overlay for NB-IoT with Non-IP PDN::
 
@@ -180,7 +180,7 @@ CONFIG_SM_NRF_CLOUD_LOCATION - nRF Cloud Location support
 
 CONFIG_SM_NRF_CLOUD_OBSERVABILITY - nRF Cloud observability support
    This option enables the ``#XNRFCLOUDOBS*`` commands, which control the Memfault data upload over the nRF Cloud CoAP transport.
-   This requires :ref:`CONFIG_SM_NRF_CLOUD <CONFIG_SM_NRF_CLOUD>` and :kconfig:option:`CONFIG_MEMFAULT_USE_NRF_CLOUD_COAP` to be enabled.
+   This requires :ref:`CONFIG_SM_NRF_CLOUD <CONFIG_SM_NRF_CLOUD>` and ``CONFIG_MEMFAULT_USE_NRF_CLOUD_COAP`` to be enabled.
    See :ref:`SM_AT_NRFCLOUDOBS` for more information.
 
 .. _CONFIG_SM_NRF_CLOUD_OBSERVABILITY_AUTO_INTERVAL_SECONDS:
@@ -371,7 +371,7 @@ The following configuration files are provided:
 
   Memfault is enabled by default in :file:`prj.conf`, without this overlay.
   Only the core dump requires the overlay, because it reserves a flash partition.
-  To build without Memfault altogether, set :kconfig:option:`CONFIG_MEMFAULT` to ``n``.
+  To build without Memfault altogether, set ``CONFIG_MEMFAULT`` to ``n``.
 
   .. note::
 

--- a/doc/uart_configuration.rst
+++ b/doc/uart_configuration.rst
@@ -427,7 +427,7 @@ The approach differs depending on whether you are using the pre-programmed nRF91
 
 **Buffer configuration:**
 
-Increase ``CONFIG_SM_UART_RX_BUF_SIZE`` and possibly ``CONFIG_SM_UART_RX_BUF_COUNT`` to provide sufficient buffer space for your use case.
+Increase :ref:`CONFIG_SM_UART_RX_BUF_SIZE <CONFIG_SM_UART_RX_BUF_SIZE>` and possibly :ref:`CONFIG_SM_UART_RX_BUF_COUNT <CONFIG_SM_UART_RX_BUF_COUNT>` to provide sufficient buffer space for your use case.
 
 Automatic UART power management using Zephyr's Cellular Modem driver
 ====================================================================


### PR DESCRIPTION
``CONFIG_SOMETHING`` should be used for non SM configs not starting with CONFIG_SM.
:ref:`CONFIG_SM_SOME <CONFIG_SM_SOME>` should be used for SM configs.