### PR TITLE
app: Respond OK for full-modem DFU commands

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -328,6 +328,7 @@ static int sm_main(void)
 	return ret;
 
 exit_reboot:
+	sm_uart_tx_flush();
 	sm_log_flush();
 	sys_reboot(SYS_REBOOT_COLD);
 }

--- a/app/src/sm_at_commands.c
+++ b/app/src/sm_at_commands.c
@@ -34,6 +34,7 @@
 #include "sm_version.h"
 #include "sm_at_nrfcloud.h"
 #include "sm_log.h"
+#include "sm_uart_handler.h"
 
 LOG_MODULE_REGISTER(sm_at, CONFIG_SM_LOG_LEVEL);
 
@@ -162,6 +163,7 @@ STATIC int handle_at_shutdown(enum at_parser_cmd_type cmd_type, struct at_parser
 FUNC_NORETURN void sm_reset(void)
 {
 	sm_power_off_modem();
+	sm_uart_tx_flush();
 	sm_log_flush();
 	sys_reboot(SYS_REBOOT_COLD);
 }

--- a/app/src/sm_at_dfu.c
+++ b/app/src/sm_at_dfu.c
@@ -334,8 +334,11 @@ static int handle_at_xdfu_init(enum at_parser_cmd_type cmd_type, struct at_parse
 				return err;
 			}
 
+			rsp_send_ok();
+
 			(void)set_full_mfw_dfu_segment_type(DFU_FULL_MFW_SEGMENT_BOOTLOADER);
 
+			sm_uart_tx_flush();
 			sm_log_flush();
 			sys_reboot(SYS_REBOOT_COLD);
 		default:
@@ -626,6 +629,14 @@ static int handle_at_xdfu_apply(enum at_parser_cmd_type cmd_type, struct at_pars
 					   DFU_FULL_MFW_SEGMENT_FIRMWARE) {
 					(void)set_full_mfw_dfu_segment_type(
 						DFU_FULL_MFW_SEGMENT_BOOTLOADER);
+					/* We are still executing a AT command, so send OK
+					 * and #XDFU URC message using rsp_send() before the
+					 * device is rebooted.
+					 */
+					rsp_send_ok();
+					rsp_send("#XDFU: %u,%u,%d\r\n", DFU_TYPE_FULL_MFW,
+						 DFU_OPERATION_APPLY_UPDATE, 0);
+					sm_uart_tx_flush();
 					LOG_INF("Firmware update successful, rebooting...");
 					sm_log_flush();
 					sys_reboot(SYS_REBOOT_COLD);

--- a/app/src/sm_at_fota.c
+++ b/app/src/sm_at_fota.c
@@ -26,6 +26,7 @@
 #include "sm_at_fota.h"
 #include "sm_defines.h"
 #include "sm_log.h"
+#include "sm_uart_handler.h"
 
 LOG_MODULE_REGISTER(sm_fota, CONFIG_SM_LOG_LEVEL);
 
@@ -626,6 +627,7 @@ FUNC_NORETURN static void handle_full_fota_activation_fail(int ret)
 		LOG_INF("External flash erase succeeded");
 
 	LOG_WRN("Rebooting...");
+	sm_uart_tx_flush();
 	sm_log_flush();
 	sys_reboot(SYS_REBOOT_COLD);
 }

--- a/app/src/sm_at_host.c
+++ b/app/src/sm_at_host.c
@@ -1135,6 +1135,7 @@ static void handle_bootloader_at_cmd(uint8_t *buf, size_t buf_size, char *at_cmd
 		}
 	} else if (strncasecmp(at_cmd, AT_XRESET_CMD, sizeof(AT_XRESET_CMD) - 1) == 0) {
 		LOG_INF("Rebooting device via %s command", AT_XRESET_CMD);
+		rsp_send_ok();
 		final_call(sm_reset);
 	} else {
 		LOG_ERR("AT command not supported in bootloader mode: %s", at_cmd);

--- a/app/src/sm_uart_handler.c
+++ b/app/src/sm_uart_handler.c
@@ -360,6 +360,23 @@ static void notify_closed_fn(struct k_work *work)
 	modem_pipe_notify_closed(&sm_pipe.pipe);
 }
 
+void sm_uart_tx_flush(void)
+{
+	k_timepoint_t timeout = sys_timepoint_calc(K_SECONDS(5));
+
+	/* Note: ring_buf_is_empty() returns true, even if ring_buf_get_finish()
+	 * has not been called yet, so compare the free space instead.
+	 */
+	while ((ring_buf_space_get(&tx_buf) != ring_buf_capacity_get(&tx_buf))
+	       && atomic_test_bit(&uart_state, SM_UART_STATE_TX_ENABLED_BIT)) {
+		sm_wait_for_pipe_event(&sm_pipe.pipe, Z_PIPE_TRANSMIT_IDLE_BIT);
+
+		if (sys_timepoint_expired(timeout)) {
+			break;
+		}
+	}
+}
+
 static int sm_uart_handler_enable(void)
 {
 	int err;

--- a/app/src/sm_uart_handler.h
+++ b/app/src/sm_uart_handler.h
@@ -35,6 +35,13 @@ typedef int (*sm_pipe_tx_t)(const uint8_t *data, size_t len, bool urc);
  */
 struct modem_pipe *sm_uart_pipe_get(void);
 
+/**
+ * @brief Wait for UART TX queues to be empty.
+ *
+ * Do not block for more than 5 seconds, even if the TX queues are not empty.
+ */
+void sm_uart_tx_flush(void);
+
 /** @} */
 
 #endif /* SM_UART_HANDLER_ */

--- a/app/src/sm_util.h
+++ b/app/src/sm_util.h
@@ -231,7 +231,19 @@ int sm_util_mcuboot_active_slot(void);
  */
 int sm_util_mcuboot_active_version(uint32_t *version);
 
-#define Z_MODEM_PIPE_EVENT_OPENED_BIT BIT(0)
+/**
+ * @defgroup sm_modem_pipe_events Modem Pipe Event Bits
+ *
+ * These are not same as the enum modem_pipe_event.
+ * See modem_pipe.c from Zephyr.
+ *
+ * @{
+ */
+#define Z_PIPE_OPENED_BIT        BIT(0)
+#define Z_PIPE_CLOSED_BIT        BIT(1)
+#define Z_PIPE_RECEIVE_READY_BIT BIT(2)
+#define Z_PIPE_TRANSMIT_IDLE_BIT BIT(3)
+/* @}*/
 
 /**
  * @brief Check whether a modem pipe is open
@@ -242,8 +254,19 @@ int sm_util_mcuboot_active_version(uint32_t *version);
  */
 static inline bool sm_pipe_is_open(struct modem_pipe *pipe)
 {
-	return k_event_test(&pipe->event, Z_MODEM_PIPE_EVENT_OPENED_BIT) ==
-	       Z_MODEM_PIPE_EVENT_OPENED_BIT;
+	return k_event_test(&pipe->event, Z_PIPE_OPENED_BIT) ==
+	       Z_PIPE_OPENED_BIT;
+}
+
+/**
+ * @brief Wait for specific event using modem pipe's internal event structure.
+ *
+ * This allows waiting for specific event on the pipe without registering the callback.
+ * See Z_MODEM_PIPE_EVENT_* definitions for events.
+ */
+static inline void sm_wait_for_pipe_event(struct modem_pipe *pipe, uint32_t events)
+{
+	k_event_wait(&pipe->event, events, false, K_SECONDS(1));
 }
 
 /**

--- a/app/tests/stubs/uart_stubs.c
+++ b/app/tests/stubs/uart_stubs.c
@@ -98,3 +98,7 @@ struct modem_pipe *sm_uart_pipe_get(void)
 	}
 	return &pipe;
 }
+
+void sm_uart_tx_flush(void)
+{
+}


### PR DESCRIPTION
Respond OK for AT#XDFUINIT=2, AT#XDFUAPPLY=2 and AT#XRESET so that common AT parsers can be used.

Try flushing UART TX queues before rebooting.