### PR TITLE
app: log: Reject a zephyr,console that is also the AT host UART

### DIFF
--- a/app/src/sm_log.c
+++ b/app/src/sm_log.c
@@ -30,6 +30,18 @@ LOG_MODULE_REGISTER(sm_log, CONFIG_SM_LOG_LEVEL);
 
 /* Zephyr console UART is used both for application logs and modem traces. */
 #define UART_DEVICE_NODE DT_CHOSEN(zephyr_console)
+
+#if DT_HAS_CHOSEN(ncs_sm_uart)
+/* sm_log_init() suspends this UART to save power. That cannot work if it is
+ * also the AT host UART: the AT host keeps asynchronous RX enabled, so
+ * pm_device_action_run(SUSPEND) returns -EAGAIN, reported as "INIT ERROR".
+ * Suspending it successfully would be worse, as it releases the pins.
+ */
+BUILD_ASSERT(!DT_SAME_NODE(DT_CHOSEN(zephyr_console), DT_CHOSEN(ncs_sm_uart)),
+	     "zephyr,console must not be the same node as ncs,sm-uart. "
+	     "Point the console at a different UART in the board devicetree.");
+#endif
+
 static const struct device *const uart_dev = DEVICE_DT_GET(UART_DEVICE_NODE);
 
 static bool log_active;

--- a/doc/app/sm_logging.rst
+++ b/doc/app/sm_logging.rst
@@ -19,6 +19,10 @@ Use ``AT#XLOG=1`` to enable application logs and resume the UART.
 This avoids UART power overhead when logs are not needed during normal operation.
 See :ref:`SM_AT_trace` for the full command reference.
 
+The ``zephyr,console`` and ``ncs,sm-uart`` chosen nodes must point to different UARTs.
+|SM| enables asynchronous reception on the AT command UART and cannot suspend it.
+The build fails if both nodes point to the same UART.
+
 .. note::
    The negative error codes that are visible in logs are *errno* codes defined in `nrf_errno.h`_.
 


### PR DESCRIPTION
`sm_log_init()` suspends the `zephyr,console` UART after boot to avoid its idle power cost, as documented in `sm_logging.rst`. That cannot work when `zephyr,console` resolves to the same node as `ncs,sm-uart`: the AT host keeps asynchronous reception enabled on its UART, so `uarte_pm_suspend()` returns `-EAGAIN`.

Today that failure surfaces only at run time, as `INIT ERROR` on the AT interface, with nothing to indicate the cause. The configuration is never valid — a *successful* suspend would be worse, since it applies `PINCTRL_STATE_SLEEP` and releases the pins of the UART the host is talking on.

This adds a `BUILD_ASSERT` so the conflict is rejected at build time, where the message can name the fix, and documents the constraint in `sm_logging.rst`. No behavior changes.

The existing docs describe the suspend and its power rationale but never state that the two UARTs must differ. It is an easy constraint to trip over on a custom board: a board whose devicetree points `zephyr,console` at its default UART and then selects the same UART for `ncs,sm-uart` builds and flashes cleanly, then reports `INIT ERROR`.

Notes for review:

- The assert is wrapped in `#if DT_HAS_CHOSEN(ncs_sm_uart)` so it does not break configurations built without an AT host UART.
- `sm_trace_backend_uart.c` uses the same `DT_CHOSEN(zephyr_console)` node. The assert lives in `sm_log.c` because that is the file whose init fails, and it is built in every default configuration while the trace backend is opt-in. Happy to move it to a shared header if you would rather cover both explicitly.

Tested on local hardware (a Circuit Dojo nRF9151 Feather): builds clean with `zephyr,console` and `ncs,sm-uart` on separate UARTs, and fails with the intended message when an overlay points both at the same UART.
