### PR TITLE
Redact sensitive data from logs with AT#XLOG=1

### DIFF
--- a/app/src/sm_at_host.c
+++ b/app/src/sm_at_host.c
@@ -13,6 +13,7 @@
 #include "sm_ppp.h"
 #include "sm_at_socket.h"
 #include "sm_cmux.h"
+#include "sm_log.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -744,8 +745,13 @@ static void raw_send(uint8_t flags)
 			send_flags |= SM_DATAMODE_FLAGS_MORE_DATA;
 		}
 
-		/* Send received data onward. */
-		LOG_HEXDUMP_DBG(data, MIN(claim, HEXDUMP_LIMIT), "RX");
+		/* Send received data onward. Data-mode payload is redacted unless AT#XLOG=2. */
+		if (sm_log_level() >= SM_LOG_ON_FULL) {
+			LOG_HEXDUMP_DBG(data, MIN(claim, HEXDUMP_LIMIT), "RX");
+		} else {
+			LOG_DBG("RX: %d bytes data-mode payload [redacted; AT#XLOG=2 to show]",
+				claim);
+		}
 		LOG_INF("Send: %d bytes, Data: %p", claim, (void *)data);
 
 		if (ctx->data_mode.handler) {
@@ -1053,8 +1059,7 @@ static int sm_at_send_internal(struct sm_at_host_ctx *ctx, const uint8_t *data, 
 				LOG_DBG("No context available for URC: %s", (const char *)data);
 				return -EIO;
 			}
-			LOG_DBG("URC default pipe=%p: %.*s", ctx->pipe, (int)len,
-				(const char *)data);
+			sm_log_urc("default", ctx->pipe, data, len);
 			ret = ring_buf_put(&urc_buf, data, len);
 			if (ret < len) {
 				LOG_ERR("URC buffer full, dropped %d bytes", len - ret);
@@ -1063,7 +1068,7 @@ static int sm_at_send_internal(struct sm_at_host_ctx *ctx, const uint8_t *data, 
 				return -EIO;
 			}
 		} else {
-			LOG_DBG("URC to pipe=%p: %.*s", ctx->pipe, (int)len, (const char *)data);
+			sm_log_urc("to", ctx->pipe, data, len);
 			/* Pipe specific URC */
 			struct urc_msg *msg = calloc(1, sizeof(struct urc_msg) + len + 1);
 
@@ -1150,7 +1155,7 @@ static void cmd_send(struct sm_at_host_ctx *ctx, uint8_t *buf, size_t cmd_length
 	/* This is safe as long as we process AT-commands sequentially in one work queue. */
 	static uint8_t response_buf[MODEM_RSP_BUF_SIZE + 1];
 
-	LOG_HEXDUMP_DBG(buf, cmd_length, "RX");
+	sm_log_rx_command(buf, cmd_length);
 
 	/* UART can send additional characters when the device is powered on.
 	 * We ignore everything before the start of the AT-command.
@@ -1213,8 +1218,15 @@ static void cmd_send(struct sm_at_host_ctx *ctx, uint8_t *buf, size_t cmd_length
 	if (strlen(response_buf) > strlen(CRLF_STR)) {
 		format_final_result(response_buf, strlen(response_buf),
 				    sizeof(response_buf));
+		/* Redact the response of sensitive commands unless AT#XLOG=2. */
+		enum sm_debug_print resp_print = SM_DEBUG_PRINT_FULL;
+
+		if (sm_log_level() < SM_LOG_ON_FULL &&
+		    sm_log_cmd_sensitive_prefix(at_cmd, cmd_length)) {
+			resp_print = SM_DEBUG_PRINT_NONE;
+		}
 		err = sm_at_send_internal(ctx, response_buf, strlen(response_buf), false,
-					  SM_DEBUG_PRINT_FULL);
+					  resp_print);
 		if (err) {
 			LOG_ERR("AT command response failed: %d", err);
 		}
@@ -1589,7 +1601,13 @@ void data_send(struct modem_pipe *pipe, const uint8_t *data, size_t len)
 		flush_pipe_urcs(ctx);
 	}
 
-	sm_at_send_internal(ctx, data, len, false, SM_DEBUG_PRINT_SHORT);
+	/* Inbound app data. Redacted unless AT#XLOG=2. */
+	if (sm_log_level() >= SM_LOG_ON_FULL) {
+		sm_at_send_internal(ctx, data, len, false, SM_DEBUG_PRINT_SHORT);
+	} else {
+		LOG_DBG("TX: %zu bytes received data [redacted; AT#XLOG=2 to show]", len);
+		sm_at_send_internal(ctx, data, len, false, SM_DEBUG_PRINT_NONE);
+	}
 }
 
 static uint16_t get_min_data_mode_idle_timeout_ms(void)

--- a/app/src/sm_at_sms.c
+++ b/app/src/sm_at_sms.c
@@ -203,13 +203,18 @@ static void sms_concat_handle(struct sms_data *const data)
 	}
 	sms_ctx.count++;
 	if (sms_ctx.count == sms_ctx.total_msgs) {
-		/* Compact the header + all message-part slots into a single,
-		 * contiguous string at the front of the buffer. memmove() is
-		 * used (instead of strcat()/strncat()) because source and
-		 * destination regions can legitimately overlap once the
-		 * write cursor catches up with a slot's own storage.
+		/* Show the header (date + sender) via rsp, but send the reassembled body
+		 * through data_send so it is redacted at AT#XLOG=1. Lock the AT host so
+		 * URCs cannot interleave the header, body and trailer.
 		 */
-		size_t pos = strnlen(sms_ctx.concat_rsp_buf, SM_SMS_AT_HEADER_INFO_MAX_LEN - 1);
+		sm_at_host_lock(sms_ctx.pipe);
+		rsp_send_to(sms_ctx.pipe, "%s", sms_ctx.concat_rsp_buf);
+
+		/* Compact the body parts to the front of the buffer (the header has already
+		 * been sent). memmove() (via sms_concat_append) is used because the source
+		 * slots and the destination can overlap.
+		 */
+		size_t pos = 0;
 
 		for (int i = 0; i < sms_ctx.total_msgs; i++) {
 			char *slot = sms_ctx.concat_rsp_buf + SM_SMS_AT_HEADER_INFO_MAX_LEN +
@@ -218,9 +223,9 @@ static void sms_concat_handle(struct sms_data *const data)
 			sms_concat_append(sms_ctx.concat_rsp_buf, concat_msg_len, &pos, slot,
 					   SMS_MAX_PAYLOAD_LEN_CHARS);
 		}
-		sms_concat_append(sms_ctx.concat_rsp_buf, concat_msg_len, &pos, "\"\r\n", 3);
-		data_send(sms_ctx.pipe, (uint8_t *)sms_ctx.concat_rsp_buf,
-			  strlen(sms_ctx.concat_rsp_buf));
+		data_send(sms_ctx.pipe, (uint8_t *)sms_ctx.concat_rsp_buf, pos);
+		rsp_send_to(sms_ctx.pipe, "\"\r\n");
+		sm_at_host_unlock(sms_ctx.pipe);
 	} else {
 		/* If new messages for the concatenated message are not received
 		 * within 3 minutes, discard the concatenated message.
@@ -244,14 +249,21 @@ STATIC void sms_callback(struct sms_data *const data, void *context)
 		struct sms_deliver_header *header = &data->header.deliver;
 
 		if (!header->concatenated.present) {
-			urc_send_to(sms_ctx.pipe,
-				"\r\n#XSMS: \"%02d-%02d-%02d %02d:%02d:%02d UTC%+03d:%02d\",\""
-				"%s\",\"%s\"\r\n",
+			/* Send header, body and trailer separately (as HTTP/CoAP do): the body
+			 * passes through data_send so it is subject to AT#XLOG redaction, with no
+			 * local copy of the payload. Lock the AT host so URCs cannot interleave.
+			 */
+			sm_at_host_lock(sms_ctx.pipe);
+			rsp_send_to(sms_ctx.pipe,
+				"\r\n#XSMS: \"%02d-%02d-%02d %02d:%02d:%02d UTC%+03d:%02d\",\"%s\",\"",
 				header->time.year, header->time.month, header->time.day,
 				header->time.hour, header->time.minute, header->time.second,
 				header->time.timezone * 15 / 60,
 				abs(header->time.timezone) * 15 % 60,
-				header->originating_address.address_str, data->payload);
+				header->originating_address.address_str);
+			data_send(sms_ctx.pipe, (const uint8_t *)data->payload, data->payload_len);
+			rsp_send_to(sms_ctx.pipe, "\"\r\n");
+			sm_at_host_unlock(sms_ctx.pipe);
 		} else {
 			sms_concat_handle(data);
 		}

--- a/app/src/sm_log.c
+++ b/app/src/sm_log.c
@@ -18,6 +18,10 @@
 /* Only compiled if zephyr,console is present and active in the devicetree. */
 #if DT_HAS_CHOSEN(zephyr_console) && DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_console), okay)
 
+#include <ctype.h>
+#include <string.h>
+#include <strings.h>
+
 #include <zephyr/drivers/uart.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -25,6 +29,7 @@
 #include <zephyr/pm/device.h>
 
 #include "sm_at_host.h"
+#include "sm_log.h"
 
 LOG_MODULE_REGISTER(sm_log, CONFIG_SM_LOG_LEVEL);
 
@@ -33,6 +38,7 @@ LOG_MODULE_REGISTER(sm_log, CONFIG_SM_LOG_LEVEL);
 static const struct device *const uart_dev = DEVICE_DT_GET(UART_DEVICE_NODE);
 
 static bool log_active;
+static int log_level;
 
 static int uart_suspend(void)
 {
@@ -78,6 +84,142 @@ void sm_log_flush(void)
 	}
 }
 
+int sm_log_level(void)
+{
+	return log_level;
+}
+
+/* Commands whose payload/credential bytes are redacted from the UART log at
+ * AT#XLOG=1 and shown only at AT#XLOG=2.
+ */
+const char *sm_log_cmd_sensitive_prefix(const char *cmd, size_t len)
+{
+	/* nRF modem commands whose argument or response carries a secret (credential,
+	 * key, token, PIN or password). Serial Modem commands which carry possibly
+	 * encrypted data.
+	 *
+	 * Currently in sync with modem releases:
+	 * - 2.0.3
+	 * - NTN 1.0.0
+	 */
+	static const char *const sensitive[] = {
+		"AT%CMNG",       /* credentials: certs, PSKs, private keys */
+		"AT%KEYGEN",     /* generated key / CSR */
+		"AT%KEYINJECT",  /* injected key material */
+		"AT%JWT",        /* signed JWT */
+		"AT%ATTESTTOKEN",
+		"AT%CLAIMTOKEN",
+		"AT%XPMNG",      /* public-key storage */
+		"AT%XSUDO",      /* signed authenticated access */
+		"AT%XUSIMLCK",   /* personalization / lock codes */
+		"AT+CPIN",       /* PIN (also matches +CPINR) */
+		"AT+CPWD",       /* password change */
+		"AT+CLCK",       /* facility password */
+		"AT+CGAUTH",     /* PDN username / password */
+		"AT#XMQTTCON",   /* MQTT connect: username / password */
+		"AT#XMQTTPUB",   /* MQTT publish: topic + message inline */
+		"AT#XMQTTSUB",   /* MQTT subscribe: topic inline */
+		"AT#XHTTPCREQ",  /* HTTP request: may carry Authorization headers */
+		"AT#XCOAPCREQ",  /* CoAP request: URI path + options (Uri-Query / Proxy-Uri) */
+		"AT#XSMS",       /* SMS send: recipient number + message text inline */
+		"AT#XSEND",      /* SM app data (also matches AT#XSENDTO) */
+		NULL,
+	};
+
+	for (size_t i = 0; sensitive[i] != NULL; i++) {
+		size_t n = strlen(sensitive[i]);
+
+		if (len < n || strncasecmp(cmd, sensitive[i], n) != 0) {
+			continue;
+		}
+		/* AT+CMD=? test syntax only lists supported parameters, never a secret. */
+		if (len >= n + 2 && cmd[n] == '=' && cmd[n + 1] == '?') {
+			return NULL;
+		}
+		return sensitive[i];
+	}
+	return NULL;
+}
+
+/* Hexdump an inbound AT command line, redacting the payload of sensitive
+ * commands unless AT#XLOG=2 (SM_LOG_ON_FULL) is set.
+ */
+void sm_log_rx_command(const uint8_t *buf, size_t len)
+{
+	size_t off = 0;
+
+	while (off + 1 < len && !(toupper(buf[off]) == 'A' && toupper(buf[off + 1]) == 'T')) {
+		off++;
+	}
+
+	const char *cmd = (const char *)buf + off;
+	size_t cmd_len = len - off;
+	const char *prefix = sm_log_cmd_sensitive_prefix(cmd, cmd_len);
+
+	if (log_level < SM_LOG_ON_FULL && prefix) {
+		size_t shown = off + strlen(prefix);
+
+		LOG_HEXDUMP_DBG(buf, shown, "RX");
+		if (len > shown) {
+			LOG_DBG("RX: [%zu bytes payload redacted; AT#XLOG=2 to show]", len - shown);
+		}
+		return;
+	}
+
+	LOG_HEXDUMP_DBG(buf, len, "RX");
+}
+
+/* URCs whose payload/credential bytes are redacted from the UART log at
+ * AT#XLOG=1 and shown only at AT#XLOG=2.
+ */
+static const char *urc_sensitive_prefix(const char *data, size_t len)
+{
+	/* nRF modem URCs which carry sensitive data.
+	 *
+	 * Currently in sync with modem releases:
+	 * - 2.0.3
+	 * - NTN 1.0.0
+	 */
+	static const char *const sensitive[] = {
+		"+CMT:", /* SMS-DELIVER: header + message PDU */
+		"+CDS:", /* SMS-STATUS-REPORT: header + delivery-report PDU (dest address) */
+		NULL,
+	};
+
+	for (size_t i = 0; sensitive[i] != NULL; i++) {
+		size_t n = strlen(sensitive[i]);
+
+		if (len >= n && strncasecmp(data, sensitive[i], n) == 0) {
+			return sensitive[i];
+		}
+	}
+	return NULL;
+}
+
+void sm_log_urc(const char *dest, const void *pipe, const uint8_t *data, size_t len)
+{
+	size_t off = 0;
+	const char *cdata = (const char *)data;
+
+	while (off < len && (cdata[off] == '\r' || cdata[off] == '\n')) {
+		off++;
+	}
+
+	const char *prefix = urc_sensitive_prefix(cdata + off, len - off);
+
+	if (log_level < SM_LOG_ON_FULL && prefix) {
+		size_t shown = off + strlen(prefix);
+
+		LOG_DBG("URC %s pipe=%p: %.*s", dest, pipe, (int)shown, cdata);
+		if (len > shown) {
+			LOG_DBG("URC %s pipe=%p: [%zu bytes PDU redacted; AT#XLOG=2 to show]",
+				dest, pipe, len - shown);
+		}
+		return;
+	}
+	LOG_DBG("URC %s pipe=%p: %.*s", dest, pipe, (int)len, cdata);
+}
+
 SM_AT_CMD_CUSTOM(xlog, "AT#XLOG", handle_at_log);
 STATIC int handle_at_log(enum at_parser_cmd_type cmd_type, struct at_parser *parser, uint32_t)
 {
@@ -88,22 +230,19 @@ STATIC int handle_at_log(enum at_parser_cmd_type cmd_type, struct at_parser *par
 	}
 
 	if (cmd_type == AT_PARSER_CMD_TYPE_SET) {
-		int mode;
-		int ret = at_parser_num_get(parser, 1, &mode);
+		int level;
+		int ret = at_parser_num_get(parser, 1, &level);
 
-		if (ret || (mode < 0) || (mode > 1)) {
+		if (ret || (level < SM_LOG_OFF) || (level > SM_LOG_ON_FULL)) {
 			return -EINVAL;
 		}
 
-		if (mode == (int)log_active) {
-			return 0;
-		}
+		const bool want_on = (level > SM_LOG_OFF);
 
-		if (mode == 1 && uart_is_active()) {
-			return -EBUSY;
-		}
-
-		if (mode == 1) {
+		if (want_on && !log_active) {
+			if (uart_is_active()) {
+				return -EBUSY;
+			}
 			ret = uart_resume();
 			if (ret) {
 				return ret;
@@ -113,7 +252,7 @@ STATIC int handle_at_log(enum at_parser_cmd_type cmd_type, struct at_parser *par
 			}
 			log_backend_enable(log_be, log_be->cb->ctx, CONFIG_LOG_DEFAULT_LEVEL);
 			log_active = true;
-		} else {
+		} else if (!want_on && log_active) {
 			log_backend_disable(log_be);
 			ret = uart_suspend();
 			if (ret) {
@@ -121,12 +260,14 @@ STATIC int handle_at_log(enum at_parser_cmd_type cmd_type, struct at_parser *par
 			}
 			log_active = false;
 		}
+
+		log_level = level;
 		return 0;
 	} else if (cmd_type == AT_PARSER_CMD_TYPE_READ) {
-		rsp_send("\r\n#XLOG: %d\r\n", (int)log_active);
+		rsp_send("\r\n#XLOG: %d\r\n", log_level);
 		return 0;
 	} else if (cmd_type == AT_PARSER_CMD_TYPE_TEST) {
-		rsp_send("\r\n#XLOG: (0,1)\r\n");
+		rsp_send("\r\n#XLOG: (0,1,2)\r\n");
 		return 0;
 	}
 
@@ -141,6 +282,7 @@ static int sm_log_init(void)
 	if (sm_bootloader_mode_enabled) {
 		/* Keep the logging (and logging UART) enabled in bootloader mode */
 		log_active = true;
+		log_level = SM_LOG_ON_FULL;
 		return 0;
 	}
 

--- a/app/src/sm_log.h
+++ b/app/src/sm_log.h
@@ -7,6 +7,10 @@
 #ifndef SM_LOG_
 #define SM_LOG_
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 /**@file sm_log.h
  *
  * @brief Log functions for Serial Modem
@@ -14,6 +18,23 @@
  */
 
 void sm_log_flush(void);
+
+/** AT#XLOG payload verbosity, also the AT#XLOG=<n> argument. */
+#define SM_LOG_OFF         0 /* Logging disabled. */
+#define SM_LOG_ON_REDACTED 1 /* Logging on; sensitive command payloads redacted. */
+#define SM_LOG_ON_FULL     2 /* Logging on; all payloads shown. */
+
+/** @brief Current AT#XLOG payload verbosity (SM_LOG_OFF / ON_REDACTED / ON_FULL). */
+int sm_log_level(void);
+
+/** @brief Sensitive-command prefix matching an AT command's argument/response, or NULL. */
+const char *sm_log_cmd_sensitive_prefix(const char *cmd, size_t len);
+
+/** @brief Hexdump an inbound AT command line, redacting sensitive payloads below AT#XLOG=2. */
+void sm_log_rx_command(const uint8_t *buf, size_t len);
+
+/** @brief Log a URC, redacting sensitive content (e.g. raw SMS PDUs) below AT#XLOG=2. */
+void sm_log_urc(const char *dest, const void *pipe, const uint8_t *data, size_t len);
 
 /** @} */
 

--- a/app/tests/stubs/sm_log_stubs.c
+++ b/app/tests/stubs/sm_log_stubs.c
@@ -4,7 +4,36 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "sm_log.h"
+
 void sm_log_flush(void)
 {
 	/* Stub - no-op for tests */
+}
+
+int sm_log_level(void)
+{
+	/* Stub - tests don't exercise redaction; report everything as shown. */
+	return SM_LOG_ON_FULL;
+}
+
+const char *sm_log_cmd_sensitive_prefix(const char *cmd, size_t len)
+{
+	(void)cmd;
+	(void)len;
+	return NULL;
+}
+
+void sm_log_rx_command(const uint8_t *buf, size_t len)
+{
+	(void)buf;
+	(void)len;
+}
+
+void sm_log_urc(const char *dest, const void *pipe, const uint8_t *data, size_t len)
+{
+	(void)dest;
+	(void)pipe;
+	(void)data;
+	(void)len;
 }

--- a/doc/app/at_trace.rst
+++ b/doc/app/at_trace.rst
@@ -46,7 +46,8 @@ Syntax
 * The ``<mode>`` parameter is an integer:
 
   * ``0`` - Disable the application log backend and suspend the UART.
-  * ``1`` - Resume the UART and enable the application log backend.
+  * ``1`` - Resume the UART and enable the application log backend. The payloads of sensitive commands are redacted from the log.
+  * ``2`` - As ``1``, but also show the payloads of sensitive commands. Use only in a trusted environment, as credentials and application data are then written to the log in clear text.
 
 
 .. note::
@@ -71,7 +72,7 @@ Response syntax
 
    #XLOG: <mode>
 
-* The ``<mode>`` parameter reflects the current state (``0`` = disabled, ``1`` = enabled).
+* The ``<mode>`` parameter reflects the current state (``0`` = disabled, ``1`` = enabled with sensitive payloads redacted, ``2`` = enabled with all payloads shown).
 
 Test command
 ------------
@@ -90,7 +91,7 @@ Response syntax
 
 ::
 
-   #XLOG: (0,1)
+   #XLOG: (0,1,2)
 
 Example
 ~~~~~~~


### PR DESCRIPTION
The intention of this change is to reduce the sensitive data that
is shown in logs while keeping the option of showing everything.

With AT#XLOG=1 redact the following in the log:
- SM commands which send and receive data.
- Data in data mode.
- Security related modem commands.

With AT#XLOG=2, everything is shown.