### PR TITLE
workflows: build: Remove normal and extmcu release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,14 +168,6 @@ jobs:
           # nRF9151 DK builds for nRF91M1
           zip_artifacts "app" "${NRF9151DK_DIR}/serial_modem.nrf91m1" "serial_modem_${VERSION}_nrf9151dk_nrf91m1" 0 "merged_nrf9151dk.hex"
 
-          # nRF9151 DK ext MCU builds
-          zip_artifacts "app" "${NRF9151DK_DIR}/serial_modem.ppp_cmux_with_extmcu" "serial_modem_${VERSION}_nrf9151dk_extmcu" 0 "merged_nrf9151dk.hex"
-          zip_artifacts "app" "${NRF9151DK_DIR}/serial_modem.ppp_cmux_with_extmcu.mtrace" "serial_modem_${VERSION}_nrf9151dk_extmcu_mtrace" 0 "merged_nrf9151dk.hex"
-
-          # nRF9151 DK normal builds (serial_modem.ppp_cmux)
-          zip_artifacts "app" "${NRF9151DK_DIR}/serial_modem.ppp_cmux" "serial_modem_${VERSION}_nrf9151dk_normal" 0 "merged_nrf9151dk.hex"
-          zip_artifacts "app" "${NRF9151DK_DIR}/serial_modem.ppp_cmux.mtrace" "serial_modem_${VERSION}_nrf9151dk_normal_mtrace" 0 "merged_nrf9151dk.hex"
-
           # nRF54L15 DK AT client shell build
           zip_artifacts "sm_at_client_shell" "${NRF54L15DK_DIR}/sm_at_client_shell/sample.sm_at_client_shell" "sm_at_client_shell_${VERSION}_nrf54l15dk" 1 "merged_nrf54l15dk.hex"
 

--- a/doc/releases/release_artifacts.rst
+++ b/doc/releases/release_artifacts.rst
@@ -12,19 +12,11 @@ The following release artifacts are available:
      - Description
    * - ``serial_modem_{VERSION}_nrf9151dk_nrf91m1``
      - nRF91M1 content for nRF9151 DK.
-   * - ``serial_modem_{VERSION}_nrf9151dk_normal``
-     - Normal build for nRF9151 DK, including PPP and CMUX support to operate with PC.
-   * - ``serial_modem_{VERSION}_nrf9151dk_normal_mtrace``
-     - Normal build with modem traces and application debug logging enabled for nRF9151 DK to operate with PC.
-   * - ``serial_modem_{VERSION}_nrf9151dk_extmcu``
-     - External MCU build for nRF9151 DK, including PPP and CMUX support.
-   * - ``serial_modem_{VERSION}_nrf9151dk_extmcu_mtrace``
-     - External MCU build with modem traces and application debug logging enabled for nRF9151 DK.
    * - ``sm_at_client_shell_{VERSION}_nrf54l15dk``
-     - AT client shell build for nRF54L15 DK host that can be used as an external MCU with ``serial_modem_{VERSION}_nrf9151dk_extmcu``.
+     - AT client shell build for nRF54L15 DK host that can be used as an external MCU.
        See :ref:`uart_configuration` for pin wiring.
    * - ``sm_ppp_shell_{VERSION}_nrf54l15dk``
-     - PPP shell build for nRF54L15 DK host that can be used as an external MCU with ``serial_modem_{VERSION}_nrf9151dk_extmcu``.
+     - PPP shell build for nRF54L15 DK host that can be used as an external MCU.
        See :ref:`uart_configuration` for pin wiring.
 
 The artifacts are zipped and contain build files such as:


### PR DESCRIPTION
Remove normal and extmcu prebuilt binaries from release artifacts. nRF91M1 binary for nRF9151 DK is the only one we provide for the app.