### PR TITLE
app: Honor <data_len> after a data mode send failure

### DIFF
--- a/app/src/sm_at_host.c
+++ b/app/src/sm_at_host.c
@@ -1400,17 +1400,26 @@ cmd_finnish_or_fail:
 	return 1;
 }
 
-/* Search for quit_str and exit datamode when one is found. */
+/* Drop data until data mode is terminated: by quit_str, or when <data_len> was given,
+ * once the remaining bytes have been received.
+ */
 static size_t null_handler(struct sm_at_host_ctx *ctx, uint8_t c)
 {
 	const char *const quit_str = CONFIG_SM_DATAMODE_TERMINATOR;
+	const bool counted = (ctx->data_mode.data_len > 0);
 	bool match = false;
 
 	if (ctx->null_dropped_count == 0) {
 		LOG_WRN("Data pipe broken. Dropping data until data mode is terminated.");
 	}
 
-	if (c == quit_str[ctx->null_match_count]) {
+	if (counted) {
+		/* As in raw_rx_handler(), quit_str is not searched for when <data_len> is set. */
+		ctx->data_mode.data_len--;
+		if (ctx->data_mode.data_len == 0) {
+			match = true;
+		}
+	} else if (c == quit_str[ctx->null_match_count]) {
 		ctx->null_match_count++;
 		if (ctx->null_match_count == strlen(quit_str)) {
 			match = true;
@@ -1421,9 +1430,11 @@ static size_t null_handler(struct sm_at_host_ctx *ctx, uint8_t c)
 	ctx->null_dropped_count++;
 
 	if (match) {
-		ctx->null_dropped_count -= strlen(quit_str);
+		if (!counted) {
+			ctx->null_dropped_count -= strlen(quit_str);
+		}
 		ctx->null_dropped_count += ring_buf_size_get(&ctx->data_rb);
-		LOG_WRN("Terminating data mode. Dropped %d bytes", ctx->null_dropped_count);
+		LOG_WRN("Terminating data mode. Dropped %zu bytes", ctx->null_dropped_count);
 		(void)exit_datamode(ctx);
 
 		ctx->null_match_count = 0;
@@ -1683,7 +1694,7 @@ void exit_datamode_handler(struct sm_at_host_ctx *ctx, int result)
 		}
 		ctx->data_mode.handler = NULL;
 		ctx->data_mode.handler_result = result;
-		ctx->data_mode.data_len = 0;
+		/* Keep data_len: null_handler() drops the remaining bytes. */
 		sm_at_host_set_current_ctx(NULL);
 	}
 }

--- a/doc/app/sm_data_mode.rst
+++ b/doc/app/sm_data_mode.rst
@@ -56,7 +56,10 @@ Sending data in data mode
 Any arbitrary data received from the MCU is sent to LTE network *as-is*.
 
 .. note::
-   If the sending operation fails due to a network problem while in data mode, the |SM| application moves to a state where the data received from UART is dropped until the MCU sends the termination command :ref:`CONFIG_SM_DATAMODE_TERMINATOR <CONFIG_SM_DATAMODE_TERMINATOR>`.
+   If sending fails while in data mode, the |SM| application drops any further data received from the UART until data mode is exited, as described in the :ref:`exiting_data_mode` section.
+   For socket, HTTP client and CoAP client commands, the |SM| application also sends the termination string :ref:`CONFIG_SM_DATAMODE_TERMINATOR <CONFIG_SM_DATAMODE_TERMINATOR>` to the MCU to indicate the error.
+
+.. _exiting_data_mode:
 
 Exiting data mode
 =================
@@ -66,18 +69,16 @@ To exit the data mode without the specification of ``<data_len>``, the MCU sends
 The pattern string could be sent alone or as an affix to the data.
 The pattern string must be sent in full.
 
-If ``<data_len>`` is specified in the AT command and the specified data length is reached, the |SM| application exits data mode. Termination command is not used in this case.
+If ``<data_len>`` is specified in the AT command and the specified data length is reached, the |SM| application exits data mode.
+The termination command is not used in this case.
+
+If a send operation fails while in data mode, such as when the socket in data mode encounters an error, the same exit conditions apply.
+The MCU must send the termination command if ``<data_len>`` is not specified.
+If ``<data_len>`` is specified, it must send the remaining bytes required to reach the specified length.
 
 When exiting the data mode, the |SM| application sends the ``#XDATAMODE`` unsolicited notification.
 
 After exiting the data mode, the |SM| application returns to the AT command mode.
-
-.. note::
-   The |SM| application sends the termination string :ref:`CONFIG_SM_DATAMODE_TERMINATOR <CONFIG_SM_DATAMODE_TERMINATOR>` and moves to a state where the data received on the UART is dropped in the following scenarios:
-
-   * The socket in data mode encounters an error.
-
-   For |SM| to stop dropping the data received from UART and move to AT-command mode, the MCU needs to send the termination command :ref:`CONFIG_SM_DATAMODE_TERMINATOR <CONFIG_SM_DATAMODE_TERMINATOR>` back to the |SM| application.
 
 Triggering the transmission
 ===========================


### PR DESCRIPTION
When a send fails in data mode, `exit_datamode_handler()` switches the AT host to a state that drops incoming data until it sees `CONFIG_SM_DATAMODE_TERMINATOR`, and zeroes `data_mode.data_len`. That is fine for terminator-based data mode, but when data mode was entered with `<data_len>` (`AT#XSEND`, `AT#XMQTTPUB`, `AT#XCOAPCPUT`, `AT#XHTTPCREQ`, ...) the MCU is following the documented contract: send exactly that many bytes, the terminator is not used. After the failure the remaining payload bytes are dropped as expected, but so is everything after them, including every subsequent AT command, until the MCU happens to send the terminator. The MCU gets no reply to anything and has no indication why. Binary payloads may also legitimately contain the terminator sequence, which is the reason `<data_len>` exists.

This keeps counting the remaining bytes after the failure in `null_handler()`, and returns to AT command mode once they have arrived, as would have happened without the error. The `#XDATAMODE: <error>` notification is then delivered at the point the MCU expects it. Terminator-based data mode is unchanged.

Also documents the behavior in `sm_data_mode.rst`.

Notes for review:

- `null_handler()` deliberately does not search for the terminator when `<data_len>` is set, matching `raw_rx_handler()`, so a payload containing the terminator bytes cannot cause an early exit.
- The dropped-byte count in the log no longer subtracts the terminator length in the counted case, since no terminator was consumed.

Found while writing a host-side recovery routine for a Circuit Dojo nRF9151 Feather: a counted `AT#XMQTTPUB` whose connection drops mid-payload leaves the AT interface silent. Build-tested locally on that hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPf18YieQdmF1vcremTUC1
