### PR TITLE
app: mqtt: Close the connection even if DISCONNECT cannot be sent

### DIFF
--- a/app/src/sm_at_mqtt.c
+++ b/app/src/sm_at_mqtt.c
@@ -560,8 +560,15 @@ static int do_mqtt_disconnect(void)
 	ctx.disconnect_requested = true;
 	err = mqtt_disconnect(&client, NULL);
 	if (err) {
-		LOG_ERR("ERROR: mqtt_disconnect %d", err);
-		return err;
+		/* A graceful DISCONNECT is not always possible. mqtt_disconnect()
+		 * checks verify_tx_state(), so it fails with -ENOTCONN whenever the
+		 * CONNACK has not arrived yet, and it fails on a broken link. Close
+		 * the connection anyway: mqtt_abort() has no such check, and leaving
+		 * ctx.connected set would strand the client with no way out.
+		 */
+		LOG_WRN("mqtt_disconnect: %d, aborting instead", err);
+		mqtt_connection_abort(err);
+		return 0;
 	}
 
 	k_work_cancel_delayable(&mqtt_keepalive_work);


### PR DESCRIPTION
**The problem**

`AT#XMQTTCON=0` calls `do_mqtt_disconnect()`, which returns early when `mqtt_disconnect()` fails (eg. before CONNACK is received), which leaves the client with no way to reach a closed state.

`mqtt_disconnect()` calls `verify_tx_state()`, so it fails with `-ENOTCONN` for the whole window between `AT#XMQTTCON=1` returning `OK` and the CONNACK arriving. That window is not short: `mqtt_connect()` returns once the CONNECT packet is written, and `ctx.connected` is set right after, so `AT#XMQTTCON?` reports `1` while the broker has not answered yet. `AT#XMQTTPUB` and `AT#XMQTTSUB` already fail with `-ENOTCONN` in that window for the same reason, which leaves `AT#XMQTTCON=0` as the only way out other than waiting for connection keepalive to expire.

Additionally, the early return leaves `ctx.disconnect_requested` set for the rest of the connection's life; it is only cleared in `do_mqtt_connect()`. The poll handler treats `POLLNVAL` as an expected disconnect while that flag is set:

```c
	if (revents & ZSOCK_POLLNVAL) {
		if (ctx.disconnect_requested) {
			/* MQTT library closed the socket during disconnect. */
			return;
		}
```

So after one failed `AT#XMQTTCON=0`, a later genuine socket failure returns quietly instead of calling `mqtt_connection_abort()`.

**This change**

With this change, if `mqtt_disconnect()` fails, `do_mqtt_disconnect()` falls back to `mqtt_connection_abort()`, which has no `verify_tx_state()` check and already performs exactly the required teardown, including releasing the AT host pipe if a publish payload drain was in progress. `AT#XMQTTCON=0` now leaves the connection closed whether or not a DISCONNECT packet could be sent.

Please note, on a link that is already broken, `AT#XMQTTCON=0` previously returned `ERROR` even though the MQTT library had already torn the connection down inside `client_write()`. It now returns `OK`. That seemed like the right contract for a command whose purpose is to end the connection — the caller cares that it is closed, not whether a final packet made it out — but say the word if you would rather it surface the error and I will return `err` after the abort instead.

The abort path is idempotent: when the library has already disconnected, `mqtt_abort()` sees `MQTT_STATE_IDLE` and does nothing, and the remaining teardown is all assignment and release of things that tolerate being released twice.

**Testing**

Tested on a Circuit Dojo nRF9151 Feather (LTE-M, mfw as shipped with NCS v3.4.0).

The window is easy to hold open indefinitely: point the client at a TCP server that accepts the connection and never answers, so the CONNACK never arrives.

```python
srv = socket.socket(); srv.bind(("0.0.0.0", 1884)); srv.listen(8)
c, a = srv.accept()          # read and discard, never reply
```

Before, with `AT#XMQTTCON=1,"","","<host>",1884`:

```
AT#XMQTTCON?                 #XMQTTCON: 1,"deadzone-test","<host>",1884
AT#XMQTTPUB="t","hello",0,0  ERROR
AT#XMQTTSUB="t",0            ERROR
AT#XMQTTCON=0                ERROR
AT#XMQTTCON?                 #XMQTTCON: 1,"deadzone-test","<host>",1884
```

Every command that could end the connection fails, and the client stays in that state until the keepalive expires. With `<keep_alive>` of 60 that took about a minute, ending in `#XMQTTEVT: 1,-113`.

After:

```
AT#XMQTTCON?                 #XMQTTCON: 1,"deadzone-test","<host>",1884
AT#XMQTTPUB="t","hello",0,0  ERROR
AT#XMQTTCON=0                OK
                             #XMQTTEVT: 1,-113
AT#XMQTTCON?                 #XMQTTCON: 0
```

`AT#XMQTTPUB` still fails, which is correct: the session is not established. Connecting again straight after the abort works, so the client is left reusable and not merely reported as closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmuCL1YNre6jonsYu9sRjY

