### PR TITLE
app: mqtt: fix memory leak - release stale connection data before reconnecting

### DIFF
--- a/app/src/sm_at_mqtt.c
+++ b/app/src/sm_at_mqtt.c
@@ -698,6 +698,10 @@ STATIC int handle_at_mqtt_connect(enum at_parser_cmd_type cmd_type, struct at_pa
 				return -EISCONN;
 			}
 
+			if (mqtt_conn != NULL) {
+				mqtt_conn_release();  /* Maybe left over after failed I/O */
+			}
+
 			mqtt_conn = calloc(1, sizeof(*mqtt_conn));
 			if (!mqtt_conn) {
 				return -ENOMEM;


### PR DESCRIPTION
When the MQTT library tears a connection down itself, `mqtt_evt_handler()` gets `MQTT_EVT_DISCONNECT` and clears `ctx.connected`, but the per-connection `mqtt_conn` allocation stays. The next `AT#XMQTTCON=1` overwrote the pointer with a fresh `calloc()`, leaking the previous struct (about 1.5 KB) on every reconnect after such a teardown.

The library does this on a failed write in `mqtt_publish()`, `mqtt_subscribe()`, `mqtt_unsubscribe()` and the QoS acknowledgements sent from the event handler, and on a failed read in `mqtt_read_publish_payload()`. Only `mqtt_connection_abort()` and the `AT#XMQTTCON=0` path release the struct.

It cannot be released from the event handler: the callback runs inside a library call that still refers to the struct, for example `mqtt_publish()` with `&mqtt_conn->pub_param`, `handle_mqtt_publish_evt()` which copies the topic into `mqtt_conn->payload_drain` after sending the acknowledgement, and `drain_publish_payload()` which is mid-payload with the AT host locked. This change releases it at the next connect instead, where nothing can be using it.

Found while reading the teardown paths for #435. No new unit test: the leak is not observable through the AT interface or the CMock boundary. Compile-checked on `circuitdojo_feather_nrf9151/nrf9151/ns`; the `at_mqtt` suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CnLo8KCsdAa3w9ySzscuo
