### PR TITLE
app: memfault: Add AT#XNRFCLOUDOBSCOREDUMP command

### DIFF
--- a/app/src/sm_at_nrfcloud_obs.c
+++ b/app/src/sm_at_nrfcloud_obs.c
@@ -20,11 +20,10 @@
 #include <memfault/http/http_client.h>
 #include <memfault/metrics/metrics.h>
 #include <memfault/ports/zephyr/http.h>
-/* MEMFAULT_BASE64_MAX_DECODE_LEN(), used to size the buffer of a forwarded chunk. */
+#include <memfault/core/data_packetizer.h>
 #include <memfault/util/base64.h>
 #if defined(CONFIG_SM_NRF_CLOUD_OBSERVABILITY_DEBUG)
 #include <memfault/core/data_export.h>
-#include <memfault/core/data_packetizer.h>
 #include <memfault/demo/cli.h>
 #endif /* CONFIG_SM_NRF_CLOUD_OBSERVABILITY_DEBUG */
 #include "sm_util.h"
@@ -71,11 +70,17 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED)
 #define OBS_FORWARD_PARAM_CHUNK		1
 #define OBS_FORWARD_PARAM_PROJECT_KEY	2
 #define OBS_CRASH_PARAM_TYPE		1
+#define OBS_COREDUMP_PARAM_ENABLE	1
 
 /* Configuration of the automatic upload, persisted under the "sm/obs" settings subtree. */
 static bool obs_auto_enabled;
 static uint32_t obs_auto_interval = CONFIG_SM_NRF_CLOUD_OBSERVABILITY_AUTO_INTERVAL_SECONDS;
 static char obs_auto_key[OBS_PROJECT_KEY_MAX_LEN + 1];
+
+/* Whether an upload drains the stored core dump, persisted under "sm/obs/coredump". When
+ * disabled the core dump stays buffered, so it can be uploaded later by re-enabling this.
+ */
+static bool obs_coredump_enabled = true;
 
 /* Whether an operation that accesses the network is ongoing. */
 static bool obs_busy;
@@ -133,6 +138,13 @@ static ssize_t obs_upload(void)
 {
 	/* Freeze the captured logs so that they are drained as well. */
 	memfault_log_trigger_collection();
+
+	/* Leave the core dump buffered when its upload is disabled. */
+	memfault_packetizer_set_active_sources(
+		obs_coredump_enabled
+			? kMfltDataSourceMask_All
+			: (kMfltDataSourceMask_Event | kMfltDataSourceMask_Log |
+			   kMfltDataSourceMask_Cdr));
 
 	return memfault_zephyr_port_post_data_return_size();
 }
@@ -201,6 +213,13 @@ STATIC int obs_settings_set(const char *name, size_t len, settings_read_cb read_
 		ret = read_cb(cb_arg, obs_auto_key, len);
 		if (ret >= 0) {
 			obs_auto_key[ret] = '\0';
+			return 0;
+		}
+	} else if (!strcmp(name, "coredump")) {
+		if (len != sizeof(obs_coredump_enabled)) {
+			return -EINVAL;
+		}
+		if (read_cb(cb_arg, &obs_coredump_enabled, len) > 0) {
 			return 0;
 		}
 	}
@@ -539,6 +558,54 @@ STATIC int handle_at_nrf_cloud_obs_auto(enum at_parser_cmd_type cmd_type, struct
 	case AT_PARSER_CMD_TYPE_TEST:
 		rsp_send("\r\n#XNRFCLOUDOBSAUTO: (0,1),(%d-%d),<project_key>\r\n",
 			 OBS_AUTO_INTERVAL_MIN, OBS_AUTO_INTERVAL_MAX);
+		return 0;
+
+	default:
+		return -ENOTSUP;
+	}
+}
+
+/*************************************************/
+/* AT#XNRFCLOUDOBSCOREDUMP                       */
+/*************************************************/
+
+SM_AT_CMD_CUSTOM(xnrfcloudobscoredump, "AT#XNRFCLOUDOBSCOREDUMP",
+		 handle_at_nrf_cloud_obs_coredump);
+STATIC int handle_at_nrf_cloud_obs_coredump(enum at_parser_cmd_type cmd_type,
+					    struct at_parser *parser, uint32_t param_count)
+{
+	ARG_UNUSED(param_count);
+
+	uint16_t enable;
+	int err;
+
+	switch (cmd_type) {
+	case AT_PARSER_CMD_TYPE_SET:
+		err = at_parser_num_get(parser, OBS_COREDUMP_PARAM_ENABLE, &enable);
+		if (err) {
+			return err;
+		}
+		if (enable > 1) {
+			return -EINVAL;
+		}
+
+		obs_coredump_enabled = enable;
+
+		err = settings_save_one("sm/obs/coredump", &obs_coredump_enabled,
+					sizeof(obs_coredump_enabled));
+		if (err) {
+			/* Applied for this session either way. */
+			LOG_WRN("Failed to store the core dump upload setting: %d", err);
+		}
+
+		return 0;
+
+	case AT_PARSER_CMD_TYPE_READ:
+		rsp_send("\r\n#XNRFCLOUDOBSCOREDUMP: %d\r\n", obs_coredump_enabled);
+		return 0;
+
+	case AT_PARSER_CMD_TYPE_TEST:
+		rsp_send("\r\n#XNRFCLOUDOBSCOREDUMP: (0,1)\r\n");
 		return 0;
 
 	default:

--- a/app/tests/at_nrfcloud/include/memfault/core/data_packetizer.h
+++ b/app/tests/at_nrfcloud/include/memfault/core/data_packetizer.h
@@ -11,7 +11,19 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+	kMfltDataSourceMask_None = 0,
+	kMfltDataSourceMask_Coredump = (1U << 0),
+	kMfltDataSourceMask_Event = (1U << 1),
+	kMfltDataSourceMask_Log = (1U << 2),
+	kMfltDataSourceMask_Cdr = (1U << 3),
+	kMfltDataSourceMask_All = (kMfltDataSourceMask_Coredump | kMfltDataSourceMask_Event |
+				   kMfltDataSourceMask_Log | kMfltDataSourceMask_Cdr)
+} eMfltDataSourceMask;
 
 bool memfault_packetizer_get_chunk(void *buf, size_t *buf_len);
+void memfault_packetizer_set_active_sources(uint32_t mask);
 
 #endif /* STUB_MEMFAULT_CORE_DATA_PACKETIZER_H_ */

--- a/app/tests/at_nrfcloud/src/memfault_stubs.c
+++ b/app/tests/at_nrfcloud/src/memfault_stubs.c
@@ -132,6 +132,11 @@ bool memfault_packetizer_get_chunk(void *buf, size_t *buf_len)
 	return true;
 }
 
+void memfault_packetizer_set_active_sources(uint32_t mask)
+{
+	(void)mask;
+}
+
 /* Minimal base64 encoder; the real one is part of the Memfault SDK. */
 void memfault_base64_encode(const void *buf, size_t buf_len, void *base64_out)
 {

--- a/doc/app/at_nrfcloud.rst
+++ b/doc/app/at_nrfcloud.rst
@@ -493,6 +493,77 @@ Response
 
    #XNRFCLOUDOBSUPLOAD: <project_key>
 
+.. _SM_AT_NRFCLOUDOBSCOREDUMP:
+
+Core dump upload #XNRFCLOUDOBSCOREDUMP
+======================================
+
+The ``#XNRFCLOUDOBSCOREDUMP`` command controls whether a stored core dump is included in an upload.
+
+When disabled, ``#XNRFCLOUDOBSUPLOAD`` and the automatic upload send the buffered events, logs, and CDRs but leave the core dump in storage, so it can be uploaded later by enabling this again.
+Core dump upload is enabled by default, and the setting is persisted.
+
+.. note::
+
+   Core dump storage holds a single core dump.
+   While a new core dump is stored, subsequent crashes do not capture a new core dump until the stored one has been uploaded.
+   Keeping the upload disabled prevents new core dumps from being captured.
+
+Set command
+-----------
+
+The set command enables or disables the core dump upload.
+
+Syntax
+~~~~~~
+
+::
+
+   AT#XNRFCLOUDOBSCOREDUMP=<enable>
+
+* The ``<enable>`` parameter is an integer.
+
+  * ``0`` - Exclude the stored core dump from uploads.
+  * ``1`` - Include the stored core dump in uploads.
+
+Read command
+------------
+
+The read command returns the current setting.
+
+Syntax
+~~~~~~
+
+::
+
+   AT#XNRFCLOUDOBSCOREDUMP?
+
+Response
+~~~~~~~~
+
+::
+
+   #XNRFCLOUDOBSCOREDUMP: <enable>
+
+Test command
+------------
+
+The test command returns the supported syntax.
+
+Syntax
+~~~~~~
+
+::
+
+   AT#XNRFCLOUDOBSCOREDUMP=?
+
+Response
+~~~~~~~~
+
+::
+
+   #XNRFCLOUDOBSCOREDUMP: (0,1)
+
 .. _SM_AT_NRFCLOUDOBSHEARTBEAT:
 
 Metrics heartbeat #XNRFCLOUDOBSHEARTBEAT


### PR DESCRIPTION
Add a command to enable or disable including the stored core dump in observability uploads. When disabled, AT#XNRFCLOUDOBSUPLOAD and the automatic upload drain only events, logs, and CDRs; the core dump stays buffered and can be uploaded later by re-enabling the option.

Implemented by restricting the Memfault packetizer in obs_upload() to the event, log, and CDR sources. The setting is persisted under the sm/obs/coredump settings key.

Core dump upload is enabled by default, preserving the previous behavior.