### PR TITLE
doc: AT command ToC cleared

### DIFF
--- a/doc/app/at_carrier.rst
+++ b/doc/app/at_carrier.rst
@@ -5,7 +5,7 @@ LwM2M carrier library AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 .. note::
 

--- a/doc/app/at_cmux.rst
+++ b/doc/app/at_cmux.rst
@@ -5,7 +5,7 @@ CMUX AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes CMUX-related AT commands.
 

--- a/doc/app/at_coap.rst
+++ b/doc/app/at_coap.rst
@@ -5,7 +5,7 @@ CoAP client AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 .. note::
 

--- a/doc/app/at_dfu.rst
+++ b/doc/app/at_dfu.rst
@@ -5,7 +5,7 @@ DFU AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes AT commands related to Device Firmware Update (DFU) operations.
 These commands allow you to update the application firmware, delta modem firmware, full modem firmware, or the MCUboot second-stage bootloader through UART.

--- a/doc/app/at_fota.rst
+++ b/doc/app/at_fota.rst
@@ -5,7 +5,7 @@ FOTA AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes AT commands related to Firmware Over-The-Air (FOTA) updates.
 

--- a/doc/app/at_generic.rst
+++ b/doc/app/at_generic.rst
@@ -5,7 +5,7 @@ Generic AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes generic AT commands.
 

--- a/doc/app/at_gnss.rst
+++ b/doc/app/at_gnss.rst
@@ -5,7 +5,7 @@ GNSS AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes GNSS-related AT commands.
 

--- a/doc/app/at_httpc.rst
+++ b/doc/app/at_httpc.rst
@@ -5,7 +5,7 @@ HTTP client AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 .. note::
 

--- a/doc/app/at_icmp.rst
+++ b/doc/app/at_icmp.rst
@@ -5,7 +5,7 @@ ICMP AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes ICMP-related AT commands.
 

--- a/doc/app/at_mqtt.rst
+++ b/doc/app/at_mqtt.rst
@@ -5,7 +5,7 @@ MQTT client AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 .. note::
 

--- a/doc/app/at_nrfcloud.rst
+++ b/doc/app/at_nrfcloud.rst
@@ -3,7 +3,7 @@ nRF Cloud AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 .. note::
 

--- a/doc/app/at_ppp.rst
+++ b/doc/app/at_ppp.rst
@@ -5,7 +5,7 @@ PPP AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes AT commands related to the Point-to-Point Protocol (PPP).
 

--- a/doc/app/at_provisioning.rst
+++ b/doc/app/at_provisioning.rst
@@ -5,7 +5,7 @@ nRF Provisioning AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 .. note::
 

--- a/doc/app/at_sms.rst
+++ b/doc/app/at_sms.rst
@@ -5,7 +5,7 @@ SMS AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes SMS-related AT commands.
 

--- a/doc/app/at_socket.rst
+++ b/doc/app/at_socket.rst
@@ -6,7 +6,7 @@ Socket AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 This page describes socket-related AT commands.
 The application can open up to 8 sockets.

--- a/doc/app/at_trace.rst
+++ b/doc/app/at_trace.rst
@@ -5,7 +5,7 @@ Trace AT commands
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 .. note::
 


### PR DESCRIPTION
Changing Table of Contents lists from 2 levels to 1 level for AT command pages. This will give only the commands in ToC and not Set/Read/Test versions for all commands.