### PR TITLE
doc: Removing experimental status from many modules

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -250,7 +250,6 @@ config SM_NRF_CLOUD
 	depends on NRF_CLOUD
 	depends on NRF_CLOUD_COAP
 	depends on DATE_TIME
-	select EXPERIMENTAL
 	select SM_BLOCKING_WORK_Q
 
 if SM_NRF_CLOUD
@@ -322,7 +321,6 @@ config SM_COAPC
 	default y
 	select COAP
 	select COAP_CLIENT
-	select EXPERIMENTAL
 	help
 	  Enable CoAP client AT commands for making CoAP requests.
 
@@ -331,7 +329,6 @@ config SM_MQTTC
 	default y
 	select MQTT_LIB
 	select MQTT_LIB_TLS
-	select EXPERIMENTAL
 
 config SM_FULL_FOTA
 	bool "Full modem FOTA support"
@@ -436,7 +433,6 @@ endif # SM_GNSS
 config SM_HTTPC
 	bool "HTTP client support"
 	default y
-	select EXPERIMENTAL
 	help
 	  Enable HTTP client AT commands for making HTTP/HTTPS requests.
 	  Uses non-blocking socket API with XAPOLL for asynchronous

--- a/doc/app/at_coap.rst
+++ b/doc/app/at_coap.rst
@@ -7,10 +7,6 @@ CoAP client AT commands
    :local:
    :depth: 1
 
-.. note::
-
-   These AT commands are `Experimental <Software maturity levels_>`_.
-
 This page describes AT commands for the CoAP client.
 The CoAP client operates on sockets managed by the :ref:`SM_AT_SOCKET`.
 You can perform the following using the Socket AT commands:

--- a/doc/app/at_httpc.rst
+++ b/doc/app/at_httpc.rst
@@ -7,10 +7,6 @@ HTTP client AT commands
    :local:
    :depth: 1
 
-.. note::
-
-   These AT commands are `Experimental <Software maturity levels_>`_.
-
 This page describes AT commands for the HTTP client.
 The HTTP client operates on sockets managed by the :ref:`SM_AT_SOCKET`.
 You can perform the following using the Socket AT commands:

--- a/doc/app/at_mqtt.rst
+++ b/doc/app/at_mqtt.rst
@@ -7,10 +7,6 @@ MQTT client AT commands
    :local:
    :depth: 1
 
-.. note::
-
-   These AT commands are `Experimental <Software maturity levels_>`_.
-
 This page describes the AT commands used to operate the MQTT client.
 
 .. note::

--- a/doc/app/at_nrfcloud.rst
+++ b/doc/app/at_nrfcloud.rst
@@ -5,10 +5,6 @@ nRF Cloud AT commands
    :local:
    :depth: 1
 
-.. note::
-
-   These AT commands are `Experimental <Software maturity levels_>`_.
-
 The page describes nRF Cloud-related AT commands.
 
 .. _SM_AT_NRFCLOUD:

--- a/doc/app/at_provisioning.rst
+++ b/doc/app/at_provisioning.rst
@@ -7,10 +7,6 @@ nRF Provisioning AT commands
    :local:
    :depth: 1
 
-.. note::
-
-   These AT commands are `Experimental <Software maturity levels_>`_.
-
 This page describes AT commands for the nRF Device Provisioning service.
 The provisioning client connects to the `nRF Cloud Provisioning Service`_ over CoAP or DTLS and applies device configuration commands (credentials, settings, and firmware updates) issued from the cloud.
 

--- a/doc/app/at_trace.rst
+++ b/doc/app/at_trace.rst
@@ -7,10 +7,6 @@ Trace AT commands
    :local:
    :depth: 1
 
-.. note::
-
-   These AT commands are `Experimental <Software maturity levels_>`_.
-
 This page describes the AT commands for controlling the shared UART trace backend.
 
 The ``AT#XLOG`` command is always available in the default build.


### PR DESCRIPTION
Removing experimental status from CoAP, HTTP, MQTT, nRF Cloud, nRF provisioning and trace AT commands.